### PR TITLE
Fix GlobalISel crashes for LLVM v16 compatibility

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -82,7 +82,7 @@ template <>
 inline std::optional<APInt> matchConstant<APInt>(Register Reg,
                                             const MachineRegisterInfo &MRI) {
   const auto& Val = matchConstant<std::optional<ValueAndVReg>>(Reg, MRI);
-  if (Val.has_value())
+  if (Val.has_value() && Val.value().has_value())
     return { Val.value()->Value };
   return { std::nullopt };
 }
@@ -98,7 +98,7 @@ template <>
 inline std::optional<int64_t> matchConstant<int64_t>(Register Reg,
                                                      const MachineRegisterInfo &MRI) {
   auto Val = matchConstant<APInt>(Reg, MRI);
-  if (Val && Val->getBitWidth() <= 64)
+  if (Val && Val->getBitWidth() > 0 && Val->getBitWidth() <= 64)
     return Val->getSExtValue();
   return std::nullopt;
 }
@@ -107,7 +107,7 @@ template <>
 inline std::optional<uint64_t> matchConstant<uint64_t>(Register Reg,
                                                        const MachineRegisterInfo &MRI) {
   auto Val = matchConstant<APInt>(Reg, MRI);
-  if (Val && Val->getBitWidth() <= 64)
+  if (Val && Val->getBitWidth() > 0 && Val->getBitWidth() <= 64)
     return Val->getSExtValue();
   return std::nullopt;
 }
@@ -116,7 +116,7 @@ template <>
 inline std::optional<unsigned char> matchConstant<unsigned char>(Register Reg,
                                                                  const MachineRegisterInfo &MRI) {
   auto Val = matchConstant<APInt>(Reg, MRI);
-  if (Val && Val->getBitWidth() <= 64)
+  if (Val && Val->getBitWidth() > 0 && Val->getBitWidth() <= 64)
     return Val->getSExtValue();
   return std::nullopt;
 }
@@ -125,7 +125,7 @@ template <>
 inline std::optional<unsigned int> matchConstant<unsigned int>(Register Reg,
                                                                const MachineRegisterInfo &MRI) {
   auto Val = matchConstant<APInt>(Reg, MRI);
-  if (Val && Val->getBitWidth() <= 64)
+  if (Val && Val->getBitWidth() > 0 && Val->getBitWidth() <= 64)
     return Val->getSExtValue();
   return std::nullopt;
 }
@@ -134,7 +134,7 @@ template <>
 inline std::optional<bool> matchConstant<bool>(Register Reg,
                                                const MachineRegisterInfo &MRI) {
   auto Val = matchConstant<APInt>(Reg, MRI);
-  if (Val && Val->getBitWidth() <= 64)
+  if (Val && Val->getBitWidth() > 0 && Val->getBitWidth() <= 64)
     return Val->getSExtValue();
   return std::nullopt;
 }

--- a/llvm/lib/Target/Z80/GISel/Z80CallLowering.cpp
+++ b/llvm/lib/Target/Z80/GISel/Z80CallLowering.cpp
@@ -762,7 +762,7 @@ bool Z80CallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
   if (!MBB.empty())
     MIRBuilder.setInstr(*MBB.begin());
 
-  OutgoingValueAssigner Assigner(CC_Z80);
+  IncomingValueAssigner Assigner(CC_Z80);
   FormalArgHandler Handler(MIRBuilder, MRI);
   if (!determineAndHandleAssignments(Handler, Assigner, SplitArgs, MIRBuilder,
                                      F.getCallingConv(), F.isVarArg()))

--- a/llvm/lib/Target/Z80/Z80Combine.td
+++ b/llvm/lib/Target/Z80/Z80Combine.td
@@ -25,24 +25,40 @@ def flip_setcc_cond : GICombineRule<
          [{ return matchFlipSetCCCond(*${mi}, MRI, ${matchinfo}); }]),
   (apply [{ applyFlipSetCCCond(*${mi}, B, Observer, *${matchinfo}); }])>;
 
+// identity combines (excluding FP related fneg_fneg_fold)
+def z80_identity_combines : GICombineGroup<[select_same_val, right_identity_zero,
+                                            binop_same_val, binop_left_to_zero,
+                                            binop_right_to_zero, p2i_to_i2p,
+                                            i2p_to_p2i, anyext_trunc_fold,
+                                            right_identity_one,
+                                            add_sub_reg, buildvector_identity_fold,
+                                            trunc_buildvector_fold,
+                                            trunc_lshr_buildvector_fold,
+                                            bitcast_bitcast_fold]>;
+
+// const combines (excluding FP related constant_fp_op, combine_minmax_nan)
+def z80_const_combines : GICombineGroup<[const_ptradd_to_i2p,
+                                         overlapping_and, mulo_by_2, mulo_by_0,
+                                         addo_by_0, adde_to_addo]>;
+
 def Z80PreLegalizerCombinerHelper
     : GICombinerHelper<"Z80GenPreLegalizerCombinerHelper", [
         and_ext, and_or_disjoint_mask, combine_ext_or_trunc, combine_identity,
-        combine_trunc_shift, constant_fold, const_combines, div_rem_to_divrem,
-        ext_ext_fold, /*fabs_fabs_fold,*/ fabs_fneg_fold, flip_cmp_cond,
+        combine_trunc_shift, constant_fold, z80_const_combines, div_rem_to_divrem,
+        ext_ext_fold, flip_cmp_cond,
         flip_setcc_cond, form_bitfield_extract, funnel_shift,
         funnel_shift_combines, hoist_logic_op_with_same_opcode_hands,
-        identity_combines, intdiv_combines, known_bits_simplifications,
+        z80_identity_combines, intdiv_combines, known_bits_simplifications,
         load_or_combine, lower_is_power_of_two, merge_unmerge, mulh_combines,
         narrow_count_zext, narrow_icmp, narrow_load, narrow_op, not_cmp_fold,
         opt_brcond_by_inverting_cond, or_to_add, phi_combines,
         ptr_add_const_immed, ptr_add_global_immed, ptr_add_immed_chain,
         ptr_add_with_zero, reassocs, reassoc_fold_consts,
-        redundant_neg_operands, select_combines, sext_to_zext,
+        select_combines, sext_to_zext,
         shift_immed_chain, shift_of_shifted_logic_chain, shl_ashr_to_sext_inreg,
         simplify_add_to_sub, simplify_const, simplify_icmp_bool,
         simplify_known_const, split_brcond, sub_const_to_add_neg,
-        trivial_combines, truncstore_merge, trunc_ext_fold, /*trunc_shl,*/
+        trivial_combines, truncstore_merge, trunc_ext_fold,
         undef_combines, unmerge_cst, unmerge_dead_to_trunc, unmerge_merge,
         unmerge_zext_to_zext, width_reduction_combines,
         xor_of_and_with_same_reg,

--- a/llvm/lib/Target/Z80/Z80MachineFunctionInfo.h
+++ b/llvm/lib/Target/Z80/Z80MachineFunctionInfo.h
@@ -52,7 +52,16 @@ private:
 public:
   Z80MachineFunctionInfo() = default;
 
-  explicit Z80MachineFunctionInfo(MachineFunction &MF) {}
+  Z80MachineFunctionInfo(const Function &F, const TargetSubtargetInfo *STI) {}
+
+  Z80MachineFunctionInfo(const Z80MachineFunctionInfo &) = default;
+
+  MachineFunctionInfo *
+  clone(BumpPtrAllocator &Allocator, MachineFunction &DestMF,
+        const DenseMap<MachineBasicBlock *, MachineBasicBlock *> &Src2DstMBB)
+      const override {
+    return DestMF.cloneInfo<Z80MachineFunctionInfo>(*this);
+  }
 
   unsigned getArgFrameSize() const { return ArgFrameSize; }
   void setArgFrameSize(unsigned Bytes) { ArgFrameSize = Bytes; }

--- a/llvm/lib/Target/Z80/Z80TargetMachine.cpp
+++ b/llvm/lib/Target/Z80/Z80TargetMachine.cpp
@@ -14,6 +14,7 @@
 #include "Z80TargetMachine.h"
 #include "TargetInfo/Z80TargetInfo.h"
 #include "Z80.h"
+#include "Z80MachineFunctionInfo.h"
 #include "Z80Subtarget.h"
 #include "Z80TargetObjectFile.h"
 #include "llvm/ADT/SmallString.h"
@@ -163,6 +164,13 @@ public:
 
 TargetPassConfig *Z80TargetMachine::createPassConfig(PassManagerBase &PM) {
   return new Z80PassConfig(*this, PM);
+}
+
+MachineFunctionInfo *Z80TargetMachine::createMachineFunctionInfo(
+    BumpPtrAllocator &Allocator, const Function &F,
+    const TargetSubtargetInfo *STI) const {
+  return Z80MachineFunctionInfo::create<Z80MachineFunctionInfo>(Allocator, F,
+                                                                STI);
 }
 
 bool Z80PassConfig::addIRTranslator() {

--- a/llvm/lib/Target/Z80/Z80TargetMachine.h
+++ b/llvm/lib/Target/Z80/Z80TargetMachine.h
@@ -36,6 +36,10 @@ public:
   TargetLoweringObjectFile *getObjFileLowering() const override {
     return TLOF.get();
   }
+
+  MachineFunctionInfo *
+  createMachineFunctionInfo(BumpPtrAllocator &Allocator, const Function &F,
+                            const TargetSubtargetInfo *STI) const override;
 };
 
 } // end namespace llvm

--- a/llvm/test/CodeGen/Z80/intrinsics.ll
+++ b/llvm/test/CodeGen/Z80/intrinsics.ll
@@ -866,7 +866,6 @@ define i64 @smax.i64(i64, i64) {
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    ld de, (ix + 6)
 ; EZ80-NEXT:    ld (ix - 3), de
-; EZ80-NEXT:    ld de, (ix + 6)
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    ld de, (ix + 18)
 ; EZ80-NEXT:    ; kill: def $bc killed $bc killed $ubc
@@ -1239,10 +1238,6 @@ define i64 @smin.i64(i64, i64) {
 ; Z80-NEXT:    bit 0, a
 ; Z80-NEXT:    ld l, (ix + 4)
 ; Z80-NEXT:    ld h, (ix + 5)
-; Z80-NEXT:    ld e, (ix + 6)
-; Z80-NEXT:    ld d, (ix + 7)
-; Z80-NEXT:    ld c, (ix + 8)
-; Z80-NEXT:    ld b, (ix + 9)
 ; Z80-NEXT:    jp z, BB11_9
 ; Z80-NEXT:  ; %bb.4:
 ; Z80-NEXT:    bit 0, a
@@ -1322,8 +1317,6 @@ define i64 @smin.i64(i64, i64) {
 ; EZ80-CODE16-NEXT:  BB11_3:
 ; EZ80-CODE16-NEXT:    bit 0, a
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 4)
-; EZ80-CODE16-NEXT:    ld de, (ix + 6)
-; EZ80-CODE16-NEXT:    ld bc, (ix + 8)
 ; EZ80-CODE16-NEXT:    jp z, BB11_9
 ; EZ80-CODE16-NEXT:  ; %bb.4:
 ; EZ80-CODE16-NEXT:    bit 0, a
@@ -1660,8 +1653,6 @@ define i64 @umax.i64(i64, i64) {
 ; Z80-NEXT:    ld h, (ix + 5)
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
-; Z80-NEXT:    ld l, (ix + 4)
-; Z80-NEXT:    ld h, (ix + 5)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    push de
 ; Z80-NEXT:    ld l, (ix + 12)
@@ -1755,7 +1746,6 @@ define i64 @umax.i64(i64, i64) {
 ; EZ80-CODE16-NEXT:    push iy
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 4)
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
-; EZ80-CODE16-NEXT:    ld hl, (ix + 4)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    push de
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 12)
@@ -1824,7 +1814,6 @@ define i64 @umax.i64(i64, i64) {
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    ld de, (ix + 6)
 ; EZ80-NEXT:    ld (ix - 3), de
-; EZ80-NEXT:    ld de, (ix + 6)
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    ld de, (ix + 18)
 ; EZ80-NEXT:    ; kill: def $bc killed $bc killed $ubc
@@ -2110,8 +2099,6 @@ define i64 @umin.i64(i64, i64) {
 ; Z80-NEXT:    ld h, (ix + 5)
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
-; Z80-NEXT:    ld l, (ix + 4)
-; Z80-NEXT:    ld h, (ix + 5)
 ; Z80-NEXT:    ld e, (ix + 6)
 ; Z80-NEXT:    ld d, (ix + 7)
 ; Z80-NEXT:    call __llcmpu
@@ -2132,46 +2119,46 @@ define i64 @umin.i64(i64, i64) {
 ; Z80-NEXT:    sbc a, a
 ; Z80-NEXT:    inc a
 ; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    jr nz, BB19_2
+; Z80-NEXT:    jp z, BB19_6
 ; Z80-NEXT:  ; %bb.1:
-; Z80-NEXT:    ld l, (ix + 12)
-; Z80-NEXT:    ld h, (ix + 13)
-; Z80-NEXT:    ld (ix - 2), l
-; Z80-NEXT:    ld (ix - 1), h
+; Z80-NEXT:    bit 0, a
+; Z80-NEXT:    jp z, BB19_7
 ; Z80-NEXT:  BB19_2:
 ; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld e, (ix + 6)
-; Z80-NEXT:    ld d, (ix + 7)
-; Z80-NEXT:    jp z, BB19_7
-; Z80-NEXT:  ; %bb.3:
-; Z80-NEXT:    bit 0, a
 ; Z80-NEXT:    jp z, BB19_8
-; Z80-NEXT:  BB19_4:
+; Z80-NEXT:  BB19_3:
 ; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    jr nz, BB19_6
-; Z80-NEXT:  BB19_5:
+; Z80-NEXT:    jr nz, BB19_5
+; Z80-NEXT:  BB19_4:
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld l, (ix + 18)
 ; Z80-NEXT:    ld h, (ix + 19)
 ; Z80-NEXT:    ex (sp), hl
 ; Z80-NEXT:    pop iy
-; Z80-NEXT:  BB19_6:
+; Z80-NEXT:  BB19_5:
 ; Z80-NEXT:    ld l, (ix - 2)
 ; Z80-NEXT:    ld h, (ix - 1)
 ; Z80-NEXT:    ld sp, ix
 ; Z80-NEXT:    pop ix
 ; Z80-NEXT:    ret
+; Z80-NEXT:  BB19_6:
+; Z80-NEXT:    ld l, (ix + 12)
+; Z80-NEXT:    ld h, (ix + 13)
+; Z80-NEXT:    ld (ix - 2), l
+; Z80-NEXT:    ld (ix - 1), h
+; Z80-NEXT:    bit 0, a
+; Z80-NEXT:    jp nz, BB19_2
 ; Z80-NEXT:  BB19_7:
 ; Z80-NEXT:    ld e, (ix + 14)
 ; Z80-NEXT:    ld d, (ix + 15)
 ; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    jp nz, BB19_4
+; Z80-NEXT:    jp nz, BB19_3
 ; Z80-NEXT:  BB19_8:
 ; Z80-NEXT:    ld c, (ix + 16)
 ; Z80-NEXT:    ld b, (ix + 17)
 ; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    jp z, BB19_5
-; Z80-NEXT:    jp BB19_6
+; Z80-NEXT:    jp z, BB19_4
+; Z80-NEXT:    jp BB19_5
 ;
 ; EZ80-CODE16-LABEL: umin.i64:
 ; EZ80-CODE16:       ; %bb.0:
@@ -2193,7 +2180,6 @@ define i64 @umin.i64(i64, i64) {
 ; EZ80-CODE16-NEXT:    push iy
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 4)
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
-; EZ80-CODE16-NEXT:    ld hl, (ix + 4)
 ; EZ80-CODE16-NEXT:    ld de, (ix + 6)
 ; EZ80-CODE16-NEXT:    call __llcmpu
 ; EZ80-CODE16-NEXT:    push af
@@ -2213,36 +2199,37 @@ define i64 @umin.i64(i64, i64) {
 ; EZ80-CODE16-NEXT:    sbc a, a
 ; EZ80-CODE16-NEXT:    inc a
 ; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    jr nz, BB19_2
+; EZ80-CODE16-NEXT:    jp z, BB19_6
 ; EZ80-CODE16-NEXT:  ; %bb.1:
-; EZ80-CODE16-NEXT:    ld hl, (ix + 12)
-; EZ80-CODE16-NEXT:    ld (ix - 2), hl
+; EZ80-CODE16-NEXT:    bit 0, a
+; EZ80-CODE16-NEXT:    jp z, BB19_7
 ; EZ80-CODE16-NEXT:  BB19_2:
 ; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    ld de, (ix + 6)
-; EZ80-CODE16-NEXT:    jp z, BB19_7
-; EZ80-CODE16-NEXT:  ; %bb.3:
-; EZ80-CODE16-NEXT:    bit 0, a
 ; EZ80-CODE16-NEXT:    jp z, BB19_8
-; EZ80-CODE16-NEXT:  BB19_4:
+; EZ80-CODE16-NEXT:  BB19_3:
 ; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    jr nz, BB19_6
-; EZ80-CODE16-NEXT:  BB19_5:
+; EZ80-CODE16-NEXT:    jr nz, BB19_5
+; EZ80-CODE16-NEXT:  BB19_4:
 ; EZ80-CODE16-NEXT:    ld iy, (ix + 18)
-; EZ80-CODE16-NEXT:  BB19_6:
+; EZ80-CODE16-NEXT:  BB19_5:
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    ld sp, ix
 ; EZ80-CODE16-NEXT:    pop ix
 ; EZ80-CODE16-NEXT:    ret
+; EZ80-CODE16-NEXT:  BB19_6:
+; EZ80-CODE16-NEXT:    ld hl, (ix + 12)
+; EZ80-CODE16-NEXT:    ld (ix - 2), hl
+; EZ80-CODE16-NEXT:    bit 0, a
+; EZ80-CODE16-NEXT:    jp nz, BB19_2
 ; EZ80-CODE16-NEXT:  BB19_7:
 ; EZ80-CODE16-NEXT:    ld de, (ix + 14)
 ; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    jp nz, BB19_4
+; EZ80-CODE16-NEXT:    jp nz, BB19_3
 ; EZ80-CODE16-NEXT:  BB19_8:
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 16)
 ; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    jp z, BB19_5
-; EZ80-CODE16-NEXT:    jp BB19_6
+; EZ80-CODE16-NEXT:    jp z, BB19_4
+; EZ80-CODE16-NEXT:    jp BB19_5
 ;
 ; EZ80-LABEL: umin.i64:
 ; EZ80:       ; %bb.0:
@@ -6263,13 +6250,6 @@ define i1 @smul.with.overflow.i64(i64, i64) {
 ; Z80-NEXT:    ld h, (ix + 9)
 ; Z80-NEXT:    ld e, (ix + 10)
 ; Z80-NEXT:    ld d, (ix + 11)
-; Z80-NEXT:    ld c, (ix + 12)
-; Z80-NEXT:    ld b, (ix + 13)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix + 14)
-; Z80-NEXT:    ld h, (ix + 15)
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    pop iy
 ; Z80-NEXT:    call __lmulu
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
@@ -6952,8 +6932,6 @@ define i1 @smul.with.overflow.i64(i64, i64) {
 ; EZ80-CODE16-NEXT:    call __lmulu
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 8)
 ; EZ80-CODE16-NEXT:    ld de, (ix + 10)
-; EZ80-CODE16-NEXT:    ld bc, (ix + 12)
-; EZ80-CODE16-NEXT:    ld iy, (ix + 14)
 ; EZ80-CODE16-NEXT:    call __lmulu
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
 ; EZ80-CODE16-NEXT:    ld (ix - 12), de
@@ -7518,15 +7496,11 @@ define i1 @smul.with.overflow.i64(i64, i64) {
 ; EZ80-NEXT:    ld bc, (ix + 15)
 ; EZ80-NEXT:    ld a, (ix - 117) ; 1-byte Folded Reload
 ; EZ80-NEXT:    call __lmulu
-; EZ80-NEXT:    ld hl, (ix + 9)
-; EZ80-NEXT:    ld (ix - 96), hl
-; EZ80-NEXT:    ld.sis hl, (ix - 95)
 ; EZ80-NEXT:    ld (ix - 3), bc
-; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -129
-; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld de, (ix)
-; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    lea hl, ix
+; EZ80-NEXT:    add hl, bc
+; EZ80-NEXT:    ld de, (hl)
 ; EZ80-NEXT:    ld iyh, e
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -136
@@ -7536,6 +7510,9 @@ define i1 @smul.with.overflow.i64(i64, i64) {
 ; EZ80-NEXT:    ld (ix), a
 ; EZ80-NEXT:    pop af
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld hl, (ix + 9)
+; EZ80-NEXT:    ld (ix - 96), hl
+; EZ80-NEXT:    ld.sis hl, (ix - 95)
 ; EZ80-NEXT:    ld (ix - 93), hl
 ; EZ80-NEXT:    push af
 ; EZ80-NEXT:    ld a, iyh
@@ -7561,28 +7538,26 @@ define i1 @smul.with.overflow.i64(i64, i64) {
 ; EZ80-NEXT:    ld (ix), hl
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    ld (ix - 120), e ; 1-byte Folded Spill
-; EZ80-NEXT:    ld hl, (ix + 18)
-; EZ80-NEXT:    ld (ix - 90), hl
-; EZ80-NEXT:    ld bc, (ix - 3)
-; EZ80-NEXT:    ld.sis bc, (ix - 89)
-; EZ80-NEXT:    ld hl, (ix - 126)
-; EZ80-NEXT:    ld a, l
-; EZ80-NEXT:    ld (ix - 3), de
+; EZ80-NEXT:    ld de, (ix - 126)
+; EZ80-NEXT:    ld a, e
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld de, -140
-; EZ80-NEXT:    add ix, de
+; EZ80-NEXT:    ld bc, -140
+; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), a
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld (ix - 87), bc
+; EZ80-NEXT:    ld hl, (ix + 18)
+; EZ80-NEXT:    ld (ix - 90), hl
+; EZ80-NEXT:    ld.sis hl, (ix - 89)
+; EZ80-NEXT:    ld (ix - 87), hl
 ; EZ80-NEXT:    ld (ix - 85), a
+; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    ld bc, (ix - 87)
-; EZ80-NEXT:    ld a, h
-; EZ80-NEXT:    dec de
+; EZ80-NEXT:    ld a, d
+; EZ80-NEXT:    ld de, -141
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, de
 ; EZ80-NEXT:    ld (hl), a
 ; EZ80-NEXT:    ld hl, (ix + 6)
-; EZ80-NEXT:    ld de, (ix - 3)
 ; EZ80-NEXT:    ld e, iyl
 ; EZ80-NEXT:    call __lmulu
 ; EZ80-NEXT:    ld (ix - 3), bc
@@ -7701,13 +7676,6 @@ define i1 @smul.with.overflow.i64(i64, i64) {
 ; EZ80-NEXT:    ld (ix), e ; 1-byte Folded Spill
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -129
-; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld hl, (ix)
-; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld (ix - 84), hl
-; EZ80-NEXT:    ld l, (ix - 82)
-; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -150
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld de, (ix)
@@ -7721,6 +7689,13 @@ define i1 @smul.with.overflow.i64(i64, i64) {
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld (ix), bc
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld de, -129
+; EZ80-NEXT:    add ix, de
+; EZ80-NEXT:    ld hl, (ix)
+; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld (ix - 84), hl
+; EZ80-NEXT:    ld l, (ix - 82)
 ; EZ80-NEXT:    ld (ix - 81), hl
 ; EZ80-NEXT:    ld.sis (ix - 80), bc
 ; EZ80-NEXT:    ld hl, (ix - 81)
@@ -7784,9 +7759,6 @@ define i1 @smul.with.overflow.i64(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), e ; 1-byte Folded Spill
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld hl, (ix - 126)
-; EZ80-NEXT:    ld (ix - 63), hl
-; EZ80-NEXT:    ld l, (ix - 61)
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -147
 ; EZ80-NEXT:    add ix, bc
@@ -7801,6 +7773,9 @@ define i1 @smul.with.overflow.i64(i64, i64) {
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld (ix), bc
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld hl, (ix - 126)
+; EZ80-NEXT:    ld (ix - 63), hl
+; EZ80-NEXT:    ld l, (ix - 61)
 ; EZ80-NEXT:    ld (ix - 60), hl
 ; EZ80-NEXT:    ld.sis (ix - 59), bc
 ; EZ80-NEXT:    ld bc, (ix - 60)
@@ -8849,8 +8824,6 @@ define i1 @umul.with.overflow.i64(i64, i64) {
 ; Z80-NEXT:    ld h, (ix + 13)
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
-; Z80-NEXT:    ld l, (ix + 12)
-; Z80-NEXT:    ld h, (ix + 13)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    push bc
 ; Z80-NEXT:    ld hl, 1
@@ -8887,7 +8860,6 @@ define i1 @umul.with.overflow.i64(i64, i64) {
 ; Z80-NEXT:    ld iyl, e
 ; Z80-NEXT:    ld iyh, d
 ; Z80-NEXT:    ex de, hl
-; Z80-NEXT:    ld bc, 0
 ; Z80-NEXT:    jr nz, BB70_4
 ; Z80-NEXT:  ; %bb.3:
 ; Z80-NEXT:    ld iyl, c
@@ -8977,7 +8949,6 @@ define i1 @umul.with.overflow.i64(i64, i64) {
 ; EZ80-CODE16-NEXT:    push iy
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 12)
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
-; EZ80-CODE16-NEXT:    ld hl, (ix + 12)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    push bc
 ; EZ80-CODE16-NEXT:    ld hl, 1
@@ -9012,7 +8983,6 @@ define i1 @umul.with.overflow.i64(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld iyl, e
 ; EZ80-CODE16-NEXT:    ld iyh, d
 ; EZ80-CODE16-NEXT:    ex de, hl
-; EZ80-CODE16-NEXT:    ld bc, 0
 ; EZ80-CODE16-NEXT:    jr nz, BB70_4
 ; EZ80-CODE16-NEXT:  ; %bb.3:
 ; EZ80-CODE16-NEXT:    ld iyl, c
@@ -9175,19 +9145,19 @@ define i8 @smul.fix.i8.7(i8, i8) {
 ; Z80:       ; %bb.0:
 ; Z80-NEXT:    ld iy, 0
 ; Z80-NEXT:    add iy, sp
-; Z80-NEXT:    ld c, (iy + 2)
-; Z80-NEXT:    ld d, (iy + 4)
+; Z80-NEXT:    ld d, (iy + 2)
+; Z80-NEXT:    ld l, (iy + 4)
 ; Z80-NEXT:    ld e, 7
-; Z80-NEXT:    ld a, c
-; Z80-NEXT:    rlc a
-; Z80-NEXT:    sbc a, a
-; Z80-NEXT:    ld h, a
-; Z80-NEXT:    ld l, c
-; Z80-NEXT:    ld a, d
+; Z80-NEXT:    ld a, l
 ; Z80-NEXT:    rlc a
 ; Z80-NEXT:    sbc a, a
 ; Z80-NEXT:    ld b, a
-; Z80-NEXT:    ld c, d
+; Z80-NEXT:    ld c, l
+; Z80-NEXT:    ld a, d
+; Z80-NEXT:    rlc a
+; Z80-NEXT:    sbc a, a
+; Z80-NEXT:    ld h, a
+; Z80-NEXT:    ld l, d
 ; Z80-NEXT:    call __smulu
 ; Z80-NEXT:    ld c, e
 ; Z80-NEXT:    call __sshrs
@@ -9198,19 +9168,19 @@ define i8 @smul.fix.i8.7(i8, i8) {
 ; EZ80-CODE16:       ; %bb.0:
 ; EZ80-CODE16-NEXT:    ld iy, 0
 ; EZ80-CODE16-NEXT:    add iy, sp
-; EZ80-CODE16-NEXT:    ld c, (iy + 2)
-; EZ80-CODE16-NEXT:    ld d, (iy + 4)
+; EZ80-CODE16-NEXT:    ld d, (iy + 2)
+; EZ80-CODE16-NEXT:    ld l, (iy + 4)
 ; EZ80-CODE16-NEXT:    ld e, 7
-; EZ80-CODE16-NEXT:    ld a, c
-; EZ80-CODE16-NEXT:    rlc a
-; EZ80-CODE16-NEXT:    sbc a, a
-; EZ80-CODE16-NEXT:    ld h, a
-; EZ80-CODE16-NEXT:    ld l, c
-; EZ80-CODE16-NEXT:    ld a, d
+; EZ80-CODE16-NEXT:    ld a, l
 ; EZ80-CODE16-NEXT:    rlc a
 ; EZ80-CODE16-NEXT:    sbc a, a
 ; EZ80-CODE16-NEXT:    ld b, a
-; EZ80-CODE16-NEXT:    ld c, d
+; EZ80-CODE16-NEXT:    ld c, l
+; EZ80-CODE16-NEXT:    ld a, d
+; EZ80-CODE16-NEXT:    rlc a
+; EZ80-CODE16-NEXT:    sbc a, a
+; EZ80-CODE16-NEXT:    ld h, a
+; EZ80-CODE16-NEXT:    ld l, d
 ; EZ80-CODE16-NEXT:    call __smulu
 ; EZ80-CODE16-NEXT:    ld c, e
 ; EZ80-CODE16-NEXT:    call __sshrs
@@ -9221,19 +9191,19 @@ define i8 @smul.fix.i8.7(i8, i8) {
 ; EZ80:       ; %bb.0:
 ; EZ80-NEXT:    ld iy, 0
 ; EZ80-NEXT:    add iy, sp
-; EZ80-NEXT:    ld c, (iy + 3)
-; EZ80-NEXT:    ld d, (iy + 6)
+; EZ80-NEXT:    ld d, (iy + 3)
+; EZ80-NEXT:    ld l, (iy + 6)
 ; EZ80-NEXT:    ld e, 7
-; EZ80-NEXT:    ld a, c
-; EZ80-NEXT:    rlc a
-; EZ80-NEXT:    sbc a, a
-; EZ80-NEXT:    ld h, a
-; EZ80-NEXT:    ld l, c
-; EZ80-NEXT:    ld a, d
+; EZ80-NEXT:    ld a, l
 ; EZ80-NEXT:    rlc a
 ; EZ80-NEXT:    sbc a, a
 ; EZ80-NEXT:    ld b, a
-; EZ80-NEXT:    ld c, d
+; EZ80-NEXT:    ld c, l
+; EZ80-NEXT:    ld a, d
+; EZ80-NEXT:    rlc a
+; EZ80-NEXT:    sbc a, a
+; EZ80-NEXT:    ld h, a
+; EZ80-NEXT:    ld l, d
 ; EZ80-NEXT:    call __smulu
 ; EZ80-NEXT:    ld c, e
 ; EZ80-NEXT:    call __sshrs
@@ -9327,42 +9297,42 @@ define i16 @smul.fix.i16.7(i16, i16) {
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld bc, (ix + 6)
-; EZ80-NEXT:    ld a, b
-; EZ80-NEXT:    ld l, a
-; EZ80-NEXT:    rlc l
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    pop de
-; EZ80-NEXT:    ld d, a
-; EZ80-NEXT:    ld e, c
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop hl
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    add iy, iy
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld (ix - 3), hl
-; EZ80-NEXT:    ld iy, (ix + 9)
-; EZ80-NEXT:    ld a, iyh
+; EZ80-NEXT:    ld de, (ix + 9)
+; EZ80-NEXT:    ld a, d
 ; EZ80-NEXT:    ld l, a
 ; EZ80-NEXT:    rlc l
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop bc
 ; EZ80-NEXT:    ld b, a
-; EZ80-NEXT:    ld c, iyl
+; EZ80-NEXT:    ld c, e
 ; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    add iy, iy
 ; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ld (ix - 3), hl
+; EZ80-NEXT:    ld iy, (ix + 6)
+; EZ80-NEXT:    ld a, iyh
+; EZ80-NEXT:    ld l, a
+; EZ80-NEXT:    rlc l
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    pop de
+; EZ80-NEXT:    ld d, a
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    add iy, iy
+; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    ex de, hl
-; EZ80-NEXT:    ld de, (ix - 3)
-; EZ80-NEXT:    ; kill: def $e killed $e killed $ude
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    ld iy, (ix - 3)
 ; EZ80-NEXT:    ld a, iyl
 ; EZ80-NEXT:    call __lmulu
 ; EZ80-NEXT:    push hl
@@ -9462,42 +9432,42 @@ define i16 @smul.fix.i16.15(i16, i16) {
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld bc, (ix + 6)
-; EZ80-NEXT:    ld a, b
-; EZ80-NEXT:    ld l, a
-; EZ80-NEXT:    rlc l
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    pop de
-; EZ80-NEXT:    ld d, a
-; EZ80-NEXT:    ld e, c
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop hl
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    add iy, iy
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld (ix - 3), hl
-; EZ80-NEXT:    ld iy, (ix + 9)
-; EZ80-NEXT:    ld a, iyh
+; EZ80-NEXT:    ld de, (ix + 9)
+; EZ80-NEXT:    ld a, d
 ; EZ80-NEXT:    ld l, a
 ; EZ80-NEXT:    rlc l
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop bc
 ; EZ80-NEXT:    ld b, a
-; EZ80-NEXT:    ld c, iyl
+; EZ80-NEXT:    ld c, e
 ; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    add iy, iy
 ; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ld (ix - 3), hl
+; EZ80-NEXT:    ld iy, (ix + 6)
+; EZ80-NEXT:    ld a, iyh
+; EZ80-NEXT:    ld l, a
+; EZ80-NEXT:    rlc l
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    pop de
+; EZ80-NEXT:    ld d, a
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    add iy, iy
+; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    ex de, hl
-; EZ80-NEXT:    ld de, (ix - 3)
-; EZ80-NEXT:    ; kill: def $e killed $e killed $ude
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    ld iy, (ix - 3)
 ; EZ80-NEXT:    ld a, iyl
 ; EZ80-NEXT:    call __lmulu
 ; EZ80-NEXT:    push hl
@@ -9616,8 +9586,8 @@ define i32 @smul.fix.i32.15(i32, i32) {
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld e, (ix + 9)
-; EZ80-NEXT:    ld a, (ix + 15)
+; EZ80-NEXT:    ld a, (ix + 9)
+; EZ80-NEXT:    ld e, (ix + 15)
 ; EZ80-NEXT:    ld l, e
 ; EZ80-NEXT:    rlc l
 ; EZ80-NEXT:    sbc hl, hl
@@ -9644,14 +9614,15 @@ define i32 @smul.fix.i32.15(i32, i32) {
 ; EZ80-NEXT:    add iy, iy
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld hl, (ix - 3)
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    ld hl, (ix + 12)
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix + 6)
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    pop de
-; EZ80-NEXT:    ld bc, (ix - 3)
-; EZ80-NEXT:    ; kill: def $bc killed $bc killed $ubc
+; EZ80-NEXT:    ld c, iyl
+; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    call __llmulu
 ; EZ80-NEXT:    ld iy, 9
 ; EZ80-NEXT:    add iy, sp
@@ -9768,8 +9739,8 @@ define i32 @smul.fix.i32.31(i32, i32) {
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld e, (ix + 9)
-; EZ80-NEXT:    ld a, (ix + 15)
+; EZ80-NEXT:    ld a, (ix + 9)
+; EZ80-NEXT:    ld e, (ix + 15)
 ; EZ80-NEXT:    ld l, e
 ; EZ80-NEXT:    rlc l
 ; EZ80-NEXT:    sbc hl, hl
@@ -9796,14 +9767,15 @@ define i32 @smul.fix.i32.31(i32, i32) {
 ; EZ80-NEXT:    add iy, iy
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld hl, (ix - 3)
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    ld hl, (ix + 12)
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix + 6)
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    pop de
-; EZ80-NEXT:    ld bc, (ix - 3)
-; EZ80-NEXT:    ; kill: def $bc killed $bc killed $ubc
+; EZ80-NEXT:    ld c, iyl
+; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    call __llmulu
 ; EZ80-NEXT:    ld iy, 9
 ; EZ80-NEXT:    add iy, sp
@@ -9873,13 +9845,6 @@ define i64 @smul.fix.i64.31(i64, i64) {
 ; Z80-NEXT:    ld h, (ix + 9)
 ; Z80-NEXT:    ld e, (ix + 10)
 ; Z80-NEXT:    ld d, (ix + 11)
-; Z80-NEXT:    ld c, (ix + 12)
-; Z80-NEXT:    ld b, (ix + 13)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix + 14)
-; Z80-NEXT:    ld h, (ix + 15)
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    pop iy
 ; Z80-NEXT:    call __lmulu
 ; Z80-NEXT:    ld (ix - 12), l
 ; Z80-NEXT:    ld (ix - 11), h
@@ -10580,8 +10545,6 @@ define i64 @smul.fix.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld (ix - 18), de
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 8)
 ; EZ80-CODE16-NEXT:    ld de, (ix + 10)
-; EZ80-CODE16-NEXT:    ld bc, (ix + 12)
-; EZ80-CODE16-NEXT:    ld iy, (ix + 14)
 ; EZ80-CODE16-NEXT:    call __lmulu
 ; EZ80-CODE16-NEXT:    ld (ix - 12), hl
 ; EZ80-CODE16-NEXT:    ld (ix - 2), de
@@ -11014,50 +10977,54 @@ define i64 @smul.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld hl, -217
 ; EZ80-NEXT:    add hl, sp
 ; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    ld bc, (ix + 9)
 ; EZ80-NEXT:    ld de, (ix + 12)
-; EZ80-NEXT:    ld bc, (ix + 21)
+; EZ80-NEXT:    ld iy, (ix + 21)
+; EZ80-NEXT:    ld a, iyh
+; EZ80-NEXT:    ld l, a
+; EZ80-NEXT:    rlc l
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ld h, a
+; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld (ix - 3), bc
+; EZ80-NEXT:    ld bc, -129
+; EZ80-NEXT:    lea iy, ix
+; EZ80-NEXT:    add iy, bc
+; EZ80-NEXT:    ld (iy), hl
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    add iy, iy
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ld bc, -156
+; EZ80-NEXT:    lea iy, ix
+; EZ80-NEXT:    add iy, bc
+; EZ80-NEXT:    ld (iy), hl
 ; EZ80-NEXT:    ld a, d
 ; EZ80-NEXT:    ld l, a
 ; EZ80-NEXT:    rlc l
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    ld h, a
 ; EZ80-NEXT:    ld l, e
-; EZ80-NEXT:    ld (ix - 3), de
-; EZ80-NEXT:    ld de, -132
-; EZ80-NEXT:    lea iy, ix
-; EZ80-NEXT:    add iy, de
-; EZ80-NEXT:    ld (iy), hl
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    add iy, iy
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld de, -159
-; EZ80-NEXT:    lea iy, ix
-; EZ80-NEXT:    add iy, de
-; EZ80-NEXT:    ld (iy), hl
-; EZ80-NEXT:    ld a, b
-; EZ80-NEXT:    ld l, a
-; EZ80-NEXT:    rlc l
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld h, a
-; EZ80-NEXT:    ld l, c
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld de, -129
-; EZ80-NEXT:    add ix, de
+; EZ80-NEXT:    ld bc, -132
+; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), hl
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    add iy, iy
 ; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld de, -156
+; EZ80-NEXT:    ld bc, -159
 ; EZ80-NEXT:    lea iy, ix
-; EZ80-NEXT:    add iy, de
+; EZ80-NEXT:    add iy, bc
 ; EZ80-NEXT:    ld (iy), hl
-; EZ80-NEXT:    ld bc, (ix + 9)
+; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    ld iyh, c
 ; EZ80-NEXT:    ld (ix - 120), bc
 ; EZ80-NEXT:    ld.sis hl, (ix - 119)
+; EZ80-NEXT:    ld (ix - 3), de
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld de, -179
 ; EZ80-NEXT:    add ix, de
@@ -11097,26 +11064,23 @@ define i64 @smul.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    ld de, (ix + 18)
 ; EZ80-NEXT:    ld iyl, e
-; EZ80-NEXT:    ld (ix - 3), bc
+; EZ80-NEXT:    ex de, hl
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -135
-; EZ80-NEXT:    add ix, bc
+; EZ80-NEXT:    ld de, -135
+; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    push af
 ; EZ80-NEXT:    ld a, iyl
 ; EZ80-NEXT:    ld (ix), a
 ; EZ80-NEXT:    pop af
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld (ix - 111), de
-; EZ80-NEXT:    ld bc, (ix - 3)
+; EZ80-NEXT:    ld (ix - 111), hl
 ; EZ80-NEXT:    ld.sis bc, (ix - 110)
-; EZ80-NEXT:    ld (ix - 3), de
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld de, -153
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld (ix), bc
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld de, (ix - 3)
-; EZ80-NEXT:    ld (ix - 108), de
+; EZ80-NEXT:    ld (ix - 108), hl
 ; EZ80-NEXT:    ld.sis de, (ix - 107)
 ; EZ80-NEXT:    ld hl, (ix + 21)
 ; EZ80-NEXT:    ld a, l
@@ -11162,9 +11126,6 @@ define i64 @smul.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), de
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld hl, (ix + 9)
-; EZ80-NEXT:    ld (ix - 102), hl
-; EZ80-NEXT:    ld.sis hl, (ix - 101)
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -132
 ; EZ80-NEXT:    add ix, bc
@@ -11176,6 +11137,9 @@ define i64 @smul.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), a
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld hl, (ix + 9)
+; EZ80-NEXT:    ld (ix - 102), hl
+; EZ80-NEXT:    ld.sis hl, (ix - 101)
 ; EZ80-NEXT:    ld (ix - 99), hl
 ; EZ80-NEXT:    ld (ix - 97), a
 ; EZ80-NEXT:    ld hl, (ix - 99)
@@ -11191,9 +11155,6 @@ define i64 @smul.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    call __lmulu
 ; EZ80-NEXT:    ld (ix - 126), hl
 ; EZ80-NEXT:    ld (ix - 123), e ; 1-byte Folded Spill
-; EZ80-NEXT:    ld hl, (ix + 18)
-; EZ80-NEXT:    ld (ix - 96), hl
-; EZ80-NEXT:    ld.sis hl, (ix - 95)
 ; EZ80-NEXT:    ld (ix - 3), bc
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -129
@@ -11206,6 +11167,9 @@ define i64 @smul.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), a
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld hl, (ix + 18)
+; EZ80-NEXT:    ld (ix - 96), hl
+; EZ80-NEXT:    ld.sis hl, (ix - 95)
 ; EZ80-NEXT:    ld (ix - 93), hl
 ; EZ80-NEXT:    ld (ix - 91), a
 ; EZ80-NEXT:    ld bc, (ix - 3)
@@ -11351,13 +11315,6 @@ define i64 @smul.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld (ix), e ; 1-byte Folded Spill
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -132
-; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld hl, (ix)
-; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld (ix - 90), hl
-; EZ80-NEXT:    ld l, (ix - 88)
-; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -159
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld de, (ix)
@@ -11371,6 +11328,13 @@ define i64 @smul.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld (ix), bc
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld de, -132
+; EZ80-NEXT:    add ix, de
+; EZ80-NEXT:    ld hl, (ix)
+; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld (ix - 90), hl
+; EZ80-NEXT:    ld l, (ix - 88)
 ; EZ80-NEXT:    ld (ix - 87), hl
 ; EZ80-NEXT:    ld.sis (ix - 86), bc
 ; EZ80-NEXT:    ld hl, (ix - 87)
@@ -11441,13 +11405,6 @@ define i64 @smul.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld (ix), e ; 1-byte Folded Spill
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -129
-; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld hl, (ix)
-; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld (ix - 69), hl
-; EZ80-NEXT:    ld l, (ix - 67)
-; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -156
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld de, (ix)
@@ -11461,6 +11418,13 @@ define i64 @smul.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld (ix), bc
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld de, -129
+; EZ80-NEXT:    add ix, de
+; EZ80-NEXT:    ld hl, (ix)
+; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld (ix - 69), hl
+; EZ80-NEXT:    ld l, (ix - 67)
 ; EZ80-NEXT:    ld (ix - 66), hl
 ; EZ80-NEXT:    ld.sis (ix - 65), bc
 ; EZ80-NEXT:    ld bc, (ix - 66)
@@ -12302,12 +12266,12 @@ define i8 @umul.fix.i8.8(i8, i8) {
 ; Z80:       ; %bb.0:
 ; Z80-NEXT:    ld iy, 0
 ; Z80-NEXT:    add iy, sp
-; Z80-NEXT:    ld h, 0
-; Z80-NEXT:    ld l, (iy + 2)
-; Z80-NEXT:    ld b, h
+; Z80-NEXT:    ld b, 0
 ; Z80-NEXT:    ld c, (iy + 4)
+; Z80-NEXT:    ld h, b
+; Z80-NEXT:    ld l, (iy + 2)
 ; Z80-NEXT:    call __smulu
-; Z80-NEXT:    ld d, 0
+; Z80-NEXT:    ld d, b
 ; Z80-NEXT:    ld e, h
 ; Z80-NEXT:    ld a, e
 ; Z80-NEXT:    ret
@@ -12316,12 +12280,12 @@ define i8 @umul.fix.i8.8(i8, i8) {
 ; EZ80-CODE16:       ; %bb.0:
 ; EZ80-CODE16-NEXT:    ld iy, 0
 ; EZ80-CODE16-NEXT:    add iy, sp
-; EZ80-CODE16-NEXT:    ld h, 0
-; EZ80-CODE16-NEXT:    ld l, (iy + 2)
-; EZ80-CODE16-NEXT:    ld b, h
+; EZ80-CODE16-NEXT:    ld b, 0
 ; EZ80-CODE16-NEXT:    ld c, (iy + 4)
+; EZ80-CODE16-NEXT:    ld h, b
+; EZ80-CODE16-NEXT:    ld l, (iy + 2)
 ; EZ80-CODE16-NEXT:    call __smulu
-; EZ80-CODE16-NEXT:    ld d, 0
+; EZ80-CODE16-NEXT:    ld d, b
 ; EZ80-CODE16-NEXT:    ld e, h
 ; EZ80-CODE16-NEXT:    ld a, e
 ; EZ80-CODE16-NEXT:    ret
@@ -12330,12 +12294,12 @@ define i8 @umul.fix.i8.8(i8, i8) {
 ; EZ80:       ; %bb.0:
 ; EZ80-NEXT:    ld iy, 0
 ; EZ80-NEXT:    add iy, sp
-; EZ80-NEXT:    ld h, 0
-; EZ80-NEXT:    ld l, (iy + 3)
-; EZ80-NEXT:    ld b, h
+; EZ80-NEXT:    ld b, 0
 ; EZ80-NEXT:    ld c, (iy + 6)
+; EZ80-NEXT:    ld h, b
+; EZ80-NEXT:    ld l, (iy + 3)
 ; EZ80-NEXT:    call __smulu
-; EZ80-NEXT:    ld d, 0
+; EZ80-NEXT:    ld d, b
 ; EZ80-NEXT:    ld e, h
 ; EZ80-NEXT:    ld a, e
 ; EZ80-NEXT:    ret
@@ -12387,14 +12351,14 @@ define i16 @umul.fix.i16.8(i16, i16) {
 ; EZ80-NEXT:    ld iy, 0
 ; EZ80-NEXT:    add iy, sp
 ; EZ80-NEXT:    ld de, (iy + 3)
-; EZ80-NEXT:    ld iy, (iy + 6)
+; EZ80-NEXT:    ld hl, (iy + 6)
+; EZ80-NEXT:    ld bc, 0
+; EZ80-NEXT:    ld c, l
+; EZ80-NEXT:    ld b, h
+; EZ80-NEXT:    xor a, a
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    ld l, e
 ; EZ80-NEXT:    ld h, d
-; EZ80-NEXT:    xor a, a
-; EZ80-NEXT:    ld bc, 0
-; EZ80-NEXT:    ld c, iyl
-; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    ld e, a
 ; EZ80-NEXT:    call __lmulu
 ; EZ80-NEXT:    push hl
@@ -12452,14 +12416,14 @@ define i16 @umul.fix.i16.16(i16, i16) {
 ; EZ80-NEXT:    ld iy, 0
 ; EZ80-NEXT:    add iy, sp
 ; EZ80-NEXT:    ld de, (iy + 3)
-; EZ80-NEXT:    ld iy, (iy + 6)
+; EZ80-NEXT:    ld hl, (iy + 6)
+; EZ80-NEXT:    ld bc, 0
+; EZ80-NEXT:    ld c, l
+; EZ80-NEXT:    ld b, h
+; EZ80-NEXT:    xor a, a
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    ld l, e
 ; EZ80-NEXT:    ld h, d
-; EZ80-NEXT:    xor a, a
-; EZ80-NEXT:    ld bc, 0
-; EZ80-NEXT:    ld c, iyl
-; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    ld e, a
 ; EZ80-NEXT:    call __lmulu
 ; EZ80-NEXT:    push hl
@@ -12549,22 +12513,18 @@ define i32 @umul.fix.i32.16(i32, i32) {
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
-; EZ80-NEXT:    ld hl, (ix + 12)
-; EZ80-NEXT:    ld a, (ix + 15)
+; EZ80-NEXT:    ld a, (ix + 9)
+; EZ80-NEXT:    ld iy, (ix + 12)
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop bc
-; EZ80-NEXT:    ld c, (ix + 9)
-; EZ80-NEXT:    ld.sis iy, 0
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    ld l, (ix + 15)
+; EZ80-NEXT:    ld.sis bc, 0
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    ld e, a
-; EZ80-NEXT:    push de
 ; EZ80-NEXT:    push hl
+; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    ld hl, (ix + 6)
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    pop de
-; EZ80-NEXT:    ld c, iyl
-; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    call __llmulu
 ; EZ80-NEXT:    ld iy, 9
 ; EZ80-NEXT:    add iy, sp
@@ -12653,22 +12613,18 @@ define i32 @umul.fix.i32.32(i32, i32) {
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
-; EZ80-NEXT:    ld hl, (ix + 12)
-; EZ80-NEXT:    ld a, (ix + 15)
+; EZ80-NEXT:    ld a, (ix + 9)
+; EZ80-NEXT:    ld iy, (ix + 12)
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop bc
-; EZ80-NEXT:    ld c, (ix + 9)
-; EZ80-NEXT:    ld.sis iy, 0
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    ld l, (ix + 15)
+; EZ80-NEXT:    ld.sis bc, 0
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    ld e, a
-; EZ80-NEXT:    push de
 ; EZ80-NEXT:    push hl
+; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    ld hl, (ix + 6)
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    pop de
-; EZ80-NEXT:    ld c, iyl
-; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    call __llmulu
 ; EZ80-NEXT:    ld iy, 9
 ; EZ80-NEXT:    add iy, sp
@@ -12712,13 +12668,6 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; Z80-NEXT:    ld h, (ix + 9)
 ; Z80-NEXT:    ld e, (ix + 10)
 ; Z80-NEXT:    ld d, (ix + 11)
-; Z80-NEXT:    ld c, (ix + 12)
-; Z80-NEXT:    ld b, (ix + 13)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix + 14)
-; Z80-NEXT:    ld h, (ix + 15)
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    pop iy
 ; Z80-NEXT:    call __lmulu
 ; Z80-NEXT:    ld (ix - 4), l
 ; Z80-NEXT:    ld (ix - 3), h
@@ -13382,8 +13331,6 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld (ix - 14), de
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 8)
 ; EZ80-CODE16-NEXT:    ld de, (ix + 10)
-; EZ80-CODE16-NEXT:    ld bc, (ix + 12)
-; EZ80-CODE16-NEXT:    ld iy, (ix + 14)
 ; EZ80-CODE16-NEXT:    call __lmulu
 ; EZ80-CODE16-NEXT:    ld (ix - 4), hl
 ; EZ80-CODE16-NEXT:    ld (ix - 2), de
@@ -13815,19 +13762,21 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    ld hl, -170
 ; EZ80-NEXT:    add hl, sp
 ; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    ld bc, (ix + 9)
 ; EZ80-NEXT:    ld de, (ix + 12)
-; EZ80-NEXT:    ld iy, 0
-; EZ80-NEXT:    ld iyl, e
-; EZ80-NEXT:    ld iyh, d
+; EZ80-NEXT:    ld iy, (ix + 21)
 ; EZ80-NEXT:    or a, a
 ; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    ld d, iyh
+; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld (ix - 117), hl
+; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    pop bc
-; EZ80-NEXT:    ld de, (ix + 21)
-; EZ80-NEXT:    ld c, e
-; EZ80-NEXT:    ld b, d
-; EZ80-NEXT:    ld (ix - 117), bc
-; EZ80-NEXT:    ld bc, (ix + 9)
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld iyl, e
+; EZ80-NEXT:    ld iyh, d
 ; EZ80-NEXT:    ld l, c
 ; EZ80-NEXT:    ex de, hl
 ; EZ80-NEXT:    ld (ix - 99), de
@@ -13840,14 +13789,14 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    ld hl, (ix + 18)
 ; EZ80-NEXT:    ld a, l
-; EZ80-NEXT:    ld (ix - 105), a
+; EZ80-NEXT:    ld (ix - 102), a
 ; EZ80-NEXT:    ld (ix - 93), hl
 ; EZ80-NEXT:    ld.sis hl, (ix - 92)
 ; EZ80-NEXT:    ld (ix - 124), hl
 ; EZ80-NEXT:    ld hl, (ix + 6)
 ; EZ80-NEXT:    ; kill: def $e killed $e killed $ude
 ; EZ80-NEXT:    ld bc, (ix + 15)
-; EZ80-NEXT:    ld a, (ix - 105) ; 1-byte Folded Reload
+; EZ80-NEXT:    ld a, (ix - 102) ; 1-byte Folded Reload
 ; EZ80-NEXT:    call __lmulu
 ; EZ80-NEXT:    ld (ix - 127), hl
 ; EZ80-NEXT:    ; kill: def $e killed $e def $ude
@@ -13857,11 +13806,11 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), de
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld a, iyl
+; EZ80-NEXT:    ld (ix - 114), a
 ; EZ80-NEXT:    ld hl, (ix + 9)
 ; EZ80-NEXT:    ld (ix - 90), hl
 ; EZ80-NEXT:    ld.sis hl, (ix - 89)
-; EZ80-NEXT:    ld a, iyl
-; EZ80-NEXT:    ld (ix - 114), a
 ; EZ80-NEXT:    ld (ix - 87), hl
 ; EZ80-NEXT:    ld (ix - 85), a
 ; EZ80-NEXT:    ld hl, (ix - 87)
@@ -13869,21 +13818,20 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    ld (ix - 111), e
 ; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    ld bc, (ix + 15)
-; EZ80-NEXT:    ld d, (ix - 105) ; 1-byte Folded Reload
-; EZ80-NEXT:    ld a, d
+; EZ80-NEXT:    ld a, (ix - 102) ; 1-byte Folded Reload
 ; EZ80-NEXT:    call __lmulu
 ; EZ80-NEXT:    ld (ix - 108), hl
-; EZ80-NEXT:    ld (ix - 102), e ; 1-byte Folded Spill
+; EZ80-NEXT:    ld (ix - 105), e ; 1-byte Folded Spill
+; EZ80-NEXT:    ld de, (ix - 117)
+; EZ80-NEXT:    ld a, e
+; EZ80-NEXT:    ld (ix - 120), a
 ; EZ80-NEXT:    ld hl, (ix + 18)
 ; EZ80-NEXT:    ld (ix - 84), hl
-; EZ80-NEXT:    ld.sis bc, (ix - 83)
-; EZ80-NEXT:    ld hl, (ix - 117)
-; EZ80-NEXT:    ld a, l
-; EZ80-NEXT:    ld (ix - 120), a
-; EZ80-NEXT:    ld (ix - 81), bc
+; EZ80-NEXT:    ld.sis hl, (ix - 83)
+; EZ80-NEXT:    ld (ix - 81), hl
 ; EZ80-NEXT:    ld (ix - 79), a
 ; EZ80-NEXT:    ld bc, (ix - 81)
-; EZ80-NEXT:    ld a, h
+; EZ80-NEXT:    ld a, d
 ; EZ80-NEXT:    ld (ix - 121), a
 ; EZ80-NEXT:    ld hl, (ix + 6)
 ; EZ80-NEXT:    ld iy, (ix - 99)
@@ -13902,7 +13850,7 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    or a, a
 ; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld l, d
+; EZ80-NEXT:    ld l, (ix - 102) ; 1-byte Folded Reload
 ; EZ80-NEXT:    ld (ix - 117), hl
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    push de
@@ -13937,7 +13885,7 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    ld de, (ix)
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    add iy, de
-; EZ80-NEXT:    ld a, (ix - 102) ; 1-byte Folded Reload
+; EZ80-NEXT:    ld a, (ix - 105) ; 1-byte Folded Reload
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -133
 ; EZ80-NEXT:    push af
@@ -13993,10 +13941,10 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), e ; 1-byte Folded Spill
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld l, a
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    ld iyl, e
 ; EZ80-NEXT:    ld iyh, d
+; EZ80-NEXT:    ld l, a
 ; EZ80-NEXT:    ld (ix - 78), hl
 ; EZ80-NEXT:    ld.sis (ix - 77), iy
 ; EZ80-NEXT:    ld bc, -154
@@ -14008,9 +13956,9 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    ld e, (ix - 73)
 ; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    ld bc, (ix + 15)
-; EZ80-NEXT:    ld a, (ix - 105) ; 1-byte Folded Reload
+; EZ80-NEXT:    ld a, (ix - 102) ; 1-byte Folded Reload
 ; EZ80-NEXT:    call __lmulu
-; EZ80-NEXT:    ld (ix - 102), hl
+; EZ80-NEXT:    ld (ix - 105), hl
 ; EZ80-NEXT:    ld (ix - 3), bc
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -157
@@ -14159,7 +14107,7 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
 ; EZ80-NEXT:    ld (hl), a
-; EZ80-NEXT:    ld iy, (ix - 102)
+; EZ80-NEXT:    ld iy, (ix - 105)
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -161
 ; EZ80-NEXT:    add ix, bc
@@ -14199,7 +14147,7 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    pop af
 ; EZ80-NEXT:    adc a, (ix) ; 1-byte Folded Reload
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld (ix - 102), a ; 1-byte Folded Spill
+; EZ80-NEXT:    ld (ix - 105), a ; 1-byte Folded Spill
 ; EZ80-NEXT:    ccf
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
@@ -14222,7 +14170,7 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    ld bc, (ix)
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    add iy, bc
-; EZ80-NEXT:    ld a, (ix - 102) ; 1-byte Folded Reload
+; EZ80-NEXT:    ld a, (ix - 105) ; 1-byte Folded Reload
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -169
 ; EZ80-NEXT:    push af
@@ -14246,7 +14194,7 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    xor a, a
 ; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    call __ladd
-; EZ80-NEXT:    ld (ix - 102), hl
+; EZ80-NEXT:    ld (ix - 105), hl
 ; EZ80-NEXT:    ld bc, (ix - 124)
 ; EZ80-NEXT:    add iy, bc
 ; EZ80-NEXT:    push ix
@@ -14262,7 +14210,7 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop bc
 ; EZ80-NEXT:    inc bc
-; EZ80-NEXT:    ld hl, (ix - 102)
+; EZ80-NEXT:    ld hl, (ix - 105)
 ; EZ80-NEXT:    xor a, a
 ; EZ80-NEXT:    call __ladd
 ; EZ80-NEXT:    ld (ix - 3), de
@@ -14277,7 +14225,7 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    ld bc, (ix)
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    add iy, bc
-; EZ80-NEXT:    ld (ix - 102), iy
+; EZ80-NEXT:    ld (ix - 105), iy
 ; EZ80-NEXT:    ld de, (ix - 3)
 ; EZ80-NEXT:    ld bc, -142
 ; EZ80-NEXT:    lea iy, ix
@@ -14317,9 +14265,9 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    ld e, a
 ; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    ld bc, (ix + 15)
-; EZ80-NEXT:    ld a, (ix - 105) ; 1-byte Folded Reload
+; EZ80-NEXT:    ld a, (ix - 102) ; 1-byte Folded Reload
 ; EZ80-NEXT:    call __lmulu
-; EZ80-NEXT:    ld (ix - 105), hl
+; EZ80-NEXT:    ld (ix - 102), hl
 ; EZ80-NEXT:    ld (ix - 3), bc
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -157
@@ -14465,7 +14413,7 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    ld d, e
-; EZ80-NEXT:    ld hl, (ix - 105)
+; EZ80-NEXT:    ld hl, (ix - 102)
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -157
 ; EZ80-NEXT:    add ix, bc
@@ -14560,7 +14508,7 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    ld (ix - 114), de
 ; EZ80-NEXT:    ld (ix - 117), bc
 ; EZ80-NEXT:    pop hl
-; EZ80-NEXT:    ld (ix - 105), iy
+; EZ80-NEXT:    ld (ix - 102), iy
 ; EZ80-NEXT:    ld e, iyl
 ; EZ80-NEXT:    ld d, iyh
 ; EZ80-NEXT:    ld (ix - 108), de
@@ -14574,7 +14522,7 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    ld (ix - 99), bc
 ; EZ80-NEXT:    ld hl, 32
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld hl, (ix - 102)
+; EZ80-NEXT:    ld hl, (ix - 105)
 ; EZ80-NEXT:    call __llshl
 ; EZ80-NEXT:    ; kill: def $bc killed $bc def $ubc
 ; EZ80-NEXT:    pop iy
@@ -14597,13 +14545,13 @@ define i64 @umul.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    ld hl, (ix - 108)
 ; EZ80-NEXT:    ld.sis (ix - 11), hl
 ; EZ80-NEXT:    ld de, (ix - 12)
-; EZ80-NEXT:    ld hl, (ix - 105)
+; EZ80-NEXT:    ld hl, (ix - 102)
 ; EZ80-NEXT:    ld (ix - 9), hl
 ; EZ80-NEXT:    ld bc, (ix - 99)
 ; EZ80-NEXT:    ld c, (ix - 7)
 ; EZ80-NEXT:    ld hl, 32
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld hl, (ix - 102)
+; EZ80-NEXT:    ld hl, (ix - 105)
 ; EZ80-NEXT:    call __llshru
 ; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    lea hl, iy
@@ -15289,7 +15237,7 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; Z80-NEXT:    push ix
 ; Z80-NEXT:    ld ix, 0
 ; Z80-NEXT:    add ix, sp
-; Z80-NEXT:    ld hl, -23
+; Z80-NEXT:    ld hl, -30
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
 ; Z80-NEXT:    push hl
@@ -15317,16 +15265,16 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; Z80-NEXT:    ld c, (ix + 8)
 ; Z80-NEXT:    ld b, (ix + 9)
 ; Z80-NEXT:    call __lldivs
-; Z80-NEXT:    ld (ix - 14), l
-; Z80-NEXT:    ld (ix - 13), h
-; Z80-NEXT:    ld (ix - 16), e
-; Z80-NEXT:    ld (ix - 15), d
-; Z80-NEXT:    ld (ix - 18), c
-; Z80-NEXT:    ld (ix - 17), b
+; Z80-NEXT:    ld (ix - 18), l
+; Z80-NEXT:    ld (ix - 17), h
+; Z80-NEXT:    ld (ix - 20), e
+; Z80-NEXT:    ld (ix - 19), d
+; Z80-NEXT:    ld (ix - 22), c
+; Z80-NEXT:    ld (ix - 21), b
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 20), l
-; Z80-NEXT:    ld (ix - 19), h
+; Z80-NEXT:    ld (ix - 24), l
+; Z80-NEXT:    ld (ix - 23), h
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
@@ -15397,57 +15345,29 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; Z80-NEXT:    ld c, (ix - 6)
 ; Z80-NEXT:    ld b, (ix - 5)
 ; Z80-NEXT:    call __llxor
-; Z80-NEXT:    ld (ix - 8), l
-; Z80-NEXT:    ld (ix - 7), h
-; Z80-NEXT:    ld (ix - 12), e
-; Z80-NEXT:    ld (ix - 11), d
+; Z80-NEXT:    ld (ix - 12), l
+; Z80-NEXT:    ld (ix - 11), h
+; Z80-NEXT:    ld (ix - 14), e
+; Z80-NEXT:    ld (ix - 13), d
+; Z80-NEXT:    ld (ix - 16), c
+; Z80-NEXT:    ld (ix - 15), b
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 22), l
-; Z80-NEXT:    ld (ix - 21), h
+; Z80-NEXT:    ld (ix - 26), l
+; Z80-NEXT:    ld (ix - 25), h
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    ld de, 0
-; Z80-NEXT:    push de
-; Z80-NEXT:    push de
-; Z80-NEXT:    ld hl, 16384
-; Z80-NEXT:    push hl
-; Z80-NEXT:    push de
 ; Z80-NEXT:    push iy
-; Z80-NEXT:    ld l, (ix - 8)
-; Z80-NEXT:    ld h, (ix - 7)
-; Z80-NEXT:    ld e, (ix - 12)
-; Z80-NEXT:    ld d, (ix - 11)
-; Z80-NEXT:    call __llcmpu
-; Z80-NEXT:    push af
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 23), l
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    ld hl, 10
-; Z80-NEXT:    add hl, sp
-; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 23)
-; Z80-NEXT:    ; kill: def $h killed $a
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    pop af
-; Z80-NEXT:    ccf
-; Z80-NEXT:    ; kill: def $a killed $a
-; Z80-NEXT:    sbc a, a
-; Z80-NEXT:    ld iyl, a
-; Z80-NEXT:    inc iyl
-; Z80-NEXT:    ld l, (ix - 22)
-; Z80-NEXT:    ld h, (ix - 21)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 8)
-; Z80-NEXT:    ld h, (ix - 7)
-; Z80-NEXT:    ld e, (ix - 12)
-; Z80-NEXT:    ld d, (ix - 11)
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
+; Z80-NEXT:    ld e, (ix - 14)
+; Z80-NEXT:    ld d, (ix - 13)
+; Z80-NEXT:    ld c, (ix - 16)
+; Z80-NEXT:    ld b, (ix - 15)
 ; Z80-NEXT:    call __llctlz
 ; Z80-NEXT:    ld l, a
-; Z80-NEXT:    ld a, iyl
 ; Z80-NEXT:    pop de
 ; Z80-NEXT:    ld h, 0
 ; Z80-NEXT:    ld de, -1
@@ -15462,9 +15382,45 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; Z80-NEXT:    call __lladd
 ; Z80-NEXT:    ld (ix - 8), l
 ; Z80-NEXT:    ld (ix - 7), h
+; Z80-NEXT:    ld (ix - 30), e
+; Z80-NEXT:    ld (ix - 29), d
+; Z80-NEXT:    ld (ix - 28), c
+; Z80-NEXT:    ld (ix - 27), b
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
+; Z80-NEXT:    ld hl, 16384
+; Z80-NEXT:    ld de, 0
+; Z80-NEXT:    push de
+; Z80-NEXT:    push de
+; Z80-NEXT:    push hl
+; Z80-NEXT:    push de
+; Z80-NEXT:    ld l, (ix - 26)
+; Z80-NEXT:    ld h, (ix - 25)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
+; Z80-NEXT:    ld e, (ix - 14)
+; Z80-NEXT:    ld d, (ix - 13)
+; Z80-NEXT:    ld c, (ix - 16)
+; Z80-NEXT:    ld b, (ix - 15)
+; Z80-NEXT:    call __llcmpu
+; Z80-NEXT:    push af
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    ld (ix - 12), l
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld hl, 10
+; Z80-NEXT:    add hl, sp
+; Z80-NEXT:    ld sp, hl
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ; kill: def $h killed $a
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    pop af
+; Z80-NEXT:    ccf
+; Z80-NEXT:    ; kill: def $a killed $a
+; Z80-NEXT:    sbc a, a
+; Z80-NEXT:    inc a
 ; Z80-NEXT:    bit 0, a
 ; Z80-NEXT:    jr z, BB88_2
 ; Z80-NEXT:  ; %bb.1:
@@ -15473,20 +15429,23 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; Z80-NEXT:    ld (ix - 7), h
 ; Z80-NEXT:  BB88_2:
 ; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld hl, 0
+; Z80-NEXT:    ld bc, 0
+; Z80-NEXT:    ld l, c
+; Z80-NEXT:    ld h, b
 ; Z80-NEXT:    jr nz, BB88_4
 ; Z80-NEXT:  ; %bb.3:
-; Z80-NEXT:    ex de, hl
+; Z80-NEXT:    ld l, (ix - 30)
+; Z80-NEXT:    ld h, (ix - 29)
 ; Z80-NEXT:  BB88_4:
 ; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld de, 0
-; Z80-NEXT:    jr nz, BB88_6
-; Z80-NEXT:  ; %bb.5:
 ; Z80-NEXT:    ld e, c
 ; Z80-NEXT:    ld d, b
+; Z80-NEXT:    jr nz, BB88_6
+; Z80-NEXT:  ; %bb.5:
+; Z80-NEXT:    ld e, (ix - 28)
+; Z80-NEXT:    ld d, (ix - 27)
 ; Z80-NEXT:  BB88_6:
 ; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld bc, 0
 ; Z80-NEXT:    jr nz, BB88_8
 ; Z80-NEXT:  ; %bb.7:
 ; Z80-NEXT:    ld c, iyl
@@ -15500,46 +15459,20 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; Z80-NEXT:    ld h, (ix - 7)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld hl, 0
-; Z80-NEXT:    ld c, l
-; Z80-NEXT:    ld b, h
-; Z80-NEXT:    push bc
+; Z80-NEXT:    ex de, hl
+; Z80-NEXT:    push de
 ; Z80-NEXT:    ex de, hl
 ; Z80-NEXT:    ld e, iyl
 ; Z80-NEXT:    ld d, iyh
 ; Z80-NEXT:    ex de, hl
-; Z80-NEXT:    ld e, c
-; Z80-NEXT:    ld d, b
+; Z80-NEXT:    ld c, e
+; Z80-NEXT:    ld b, d
 ; Z80-NEXT:    call __llsub
 ; Z80-NEXT:    ld (ix - 12), l
 ; Z80-NEXT:    ld (ix - 11), h
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    ld hl, 31
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 20)
-; Z80-NEXT:    ld h, (ix - 19)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 14)
-; Z80-NEXT:    ld h, (ix - 13)
-; Z80-NEXT:    ld e, (ix - 16)
-; Z80-NEXT:    ld d, (ix - 15)
-; Z80-NEXT:    ld c, (ix - 18)
-; Z80-NEXT:    ld b, (ix - 17)
-; Z80-NEXT:    call __llshl
-; Z80-NEXT:    ld (ix - 14), l
-; Z80-NEXT:    ld (ix - 13), h
-; Z80-NEXT:    ld (ix - 16), e
-; Z80-NEXT:    ld (ix - 15), d
-; Z80-NEXT:    ld (ix - 18), c
-; Z80-NEXT:    ld (ix - 17), b
-; Z80-NEXT:    push iy
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 20), l
-; Z80-NEXT:    ld (ix - 19), h
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    pop hl
 ; Z80-NEXT:    ld l, (ix - 8)
 ; Z80-NEXT:    ld h, (ix - 7)
 ; Z80-NEXT:    push hl
@@ -15640,23 +15573,48 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; Z80-NEXT:    call __llshrs
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld (ix - 4), e
+; Z80-NEXT:    ld (ix - 3), d
+; Z80-NEXT:    ld (ix - 6), c
+; Z80-NEXT:    ld (ix - 5), b
 ; Z80-NEXT:    push iy
-; Z80-NEXT:    push bc
-; Z80-NEXT:    push de
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    ld (ix - 8), l
+; Z80-NEXT:    ld (ix - 7), h
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld hl, 31
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 24)
+; Z80-NEXT:    ld h, (ix - 23)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 18)
+; Z80-NEXT:    ld h, (ix - 17)
+; Z80-NEXT:    ld e, (ix - 20)
+; Z80-NEXT:    ld d, (ix - 19)
+; Z80-NEXT:    ld c, (ix - 22)
+; Z80-NEXT:    ld b, (ix - 21)
+; Z80-NEXT:    call __llshl
+; Z80-NEXT:    ld (ix - 10), l
+; Z80-NEXT:    ld (ix - 9), h
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld l, (ix - 8)
+; Z80-NEXT:    ld h, (ix - 7)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 6)
+; Z80-NEXT:    ld h, (ix - 5)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 4)
+; Z80-NEXT:    ld h, (ix - 3)
+; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld l, (ix - 2)
 ; Z80-NEXT:    ld h, (ix - 1)
 ; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 20)
-; Z80-NEXT:    ld h, (ix - 19)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 14)
-; Z80-NEXT:    ld h, (ix - 13)
-; Z80-NEXT:    ld e, (ix - 16)
-; Z80-NEXT:    ld d, (ix - 15)
-; Z80-NEXT:    ld c, (ix - 18)
-; Z80-NEXT:    ld b, (ix - 17)
+; Z80-NEXT:    push iy
+; Z80-NEXT:    ld l, (ix - 10)
+; Z80-NEXT:    ld h, (ix - 9)
 ; Z80-NEXT:    call __lladd
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
@@ -15674,7 +15632,7 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    push ix
 ; EZ80-CODE16-NEXT:    ld ix, 0
 ; EZ80-CODE16-NEXT:    add ix, sp
-; EZ80-CODE16-NEXT:    lea hl, ix - 23
+; EZ80-CODE16-NEXT:    lea hl, ix - 30
 ; EZ80-CODE16-NEXT:    ld sp, hl
 ; EZ80-CODE16-NEXT:    ld iy, (ix + 12)
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 14)
@@ -15690,10 +15648,10 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld de, (ix + 6)
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 8)
 ; EZ80-CODE16-NEXT:    call __lldivs
-; EZ80-CODE16-NEXT:    ld (ix - 14), hl
-; EZ80-CODE16-NEXT:    ld (ix - 16), de
-; EZ80-CODE16-NEXT:    ld (ix - 18), bc
-; EZ80-CODE16-NEXT:    ld (ix - 20), iy
+; EZ80-CODE16-NEXT:    ld (ix - 18), hl
+; EZ80-CODE16-NEXT:    ld (ix - 20), de
+; EZ80-CODE16-NEXT:    ld (ix - 22), bc
+; EZ80-CODE16-NEXT:    ld (ix - 24), iy
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
@@ -15740,46 +15698,19 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld de, (ix - 4)
 ; EZ80-CODE16-NEXT:    ld bc, (ix - 6)
 ; EZ80-CODE16-NEXT:    call __llxor
-; EZ80-CODE16-NEXT:    ld (ix - 8), hl
-; EZ80-CODE16-NEXT:    ld (ix - 12), de
-; EZ80-CODE16-NEXT:    ld (ix - 22), iy
+; EZ80-CODE16-NEXT:    ld (ix - 12), hl
+; EZ80-CODE16-NEXT:    ld (ix - 14), de
+; EZ80-CODE16-NEXT:    ld (ix - 16), bc
+; EZ80-CODE16-NEXT:    ld (ix - 26), iy
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld de, 0
-; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    ld hl, 16384
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    push de
 ; EZ80-CODE16-NEXT:    push iy
-; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
-; EZ80-CODE16-NEXT:    ld de, (ix - 12)
-; EZ80-CODE16-NEXT:    call __llcmpu
-; EZ80-CODE16-NEXT:    push af
-; EZ80-CODE16-NEXT:    ex (sp), hl
-; EZ80-CODE16-NEXT:    ld (ix - 23), l
-; EZ80-CODE16-NEXT:    pop hl
-; EZ80-CODE16-NEXT:    ld hl, 10
-; EZ80-CODE16-NEXT:    add hl, sp
-; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld l, (ix - 23)
-; EZ80-CODE16-NEXT:    ; kill: def $h killed $a
-; EZ80-CODE16-NEXT:    ex (sp), hl
-; EZ80-CODE16-NEXT:    pop af
-; EZ80-CODE16-NEXT:    ccf
-; EZ80-CODE16-NEXT:    ; kill: def $a killed $a
-; EZ80-CODE16-NEXT:    sbc a, a
-; EZ80-CODE16-NEXT:    ld iyl, a
-; EZ80-CODE16-NEXT:    inc iyl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 22)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
-; EZ80-CODE16-NEXT:    ld de, (ix - 12)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
+; EZ80-CODE16-NEXT:    ld de, (ix - 14)
+; EZ80-CODE16-NEXT:    ld bc, (ix - 16)
 ; EZ80-CODE16-NEXT:    call __llctlz
 ; EZ80-CODE16-NEXT:    ld l, a
-; EZ80-CODE16-NEXT:    ld a, iyl
 ; EZ80-CODE16-NEXT:    pop de
 ; EZ80-CODE16-NEXT:    ld h, 0
 ; EZ80-CODE16-NEXT:    ld de, -1
@@ -15793,9 +15724,39 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld d, b
 ; EZ80-CODE16-NEXT:    call __lladd
 ; EZ80-CODE16-NEXT:    ld (ix - 8), hl
+; EZ80-CODE16-NEXT:    ld (ix - 30), de
+; EZ80-CODE16-NEXT:    ld (ix - 28), bc
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
+; EZ80-CODE16-NEXT:    ld hl, 16384
+; EZ80-CODE16-NEXT:    ld de, 0
+; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    ld hl, (ix - 26)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
+; EZ80-CODE16-NEXT:    ld de, (ix - 14)
+; EZ80-CODE16-NEXT:    ld bc, (ix - 16)
+; EZ80-CODE16-NEXT:    call __llcmpu
+; EZ80-CODE16-NEXT:    push af
+; EZ80-CODE16-NEXT:    ex (sp), hl
+; EZ80-CODE16-NEXT:    ld (ix - 12), l
+; EZ80-CODE16-NEXT:    pop hl
+; EZ80-CODE16-NEXT:    ld hl, 10
+; EZ80-CODE16-NEXT:    add hl, sp
+; EZ80-CODE16-NEXT:    ld sp, hl
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld l, (ix - 12)
+; EZ80-CODE16-NEXT:    ; kill: def $h killed $a
+; EZ80-CODE16-NEXT:    ex (sp), hl
+; EZ80-CODE16-NEXT:    pop af
+; EZ80-CODE16-NEXT:    ccf
+; EZ80-CODE16-NEXT:    ; kill: def $a killed $a
+; EZ80-CODE16-NEXT:    sbc a, a
+; EZ80-CODE16-NEXT:    inc a
 ; EZ80-CODE16-NEXT:    bit 0, a
 ; EZ80-CODE16-NEXT:    jr z, BB88_2
 ; EZ80-CODE16-NEXT:  ; %bb.1:
@@ -15803,20 +15764,21 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld (ix - 8), hl
 ; EZ80-CODE16-NEXT:  BB88_2:
 ; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    ld hl, 0
+; EZ80-CODE16-NEXT:    ld bc, 0
+; EZ80-CODE16-NEXT:    ld l, c
+; EZ80-CODE16-NEXT:    ld h, b
 ; EZ80-CODE16-NEXT:    jr nz, BB88_4
 ; EZ80-CODE16-NEXT:  ; %bb.3:
-; EZ80-CODE16-NEXT:    ex de, hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 30)
 ; EZ80-CODE16-NEXT:  BB88_4:
 ; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    ld de, 0
-; EZ80-CODE16-NEXT:    jr nz, BB88_6
-; EZ80-CODE16-NEXT:  ; %bb.5:
 ; EZ80-CODE16-NEXT:    ld e, c
 ; EZ80-CODE16-NEXT:    ld d, b
+; EZ80-CODE16-NEXT:    jr nz, BB88_6
+; EZ80-CODE16-NEXT:  ; %bb.5:
+; EZ80-CODE16-NEXT:    ld de, (ix - 28)
 ; EZ80-CODE16-NEXT:  BB88_6:
 ; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    ld bc, 0
 ; EZ80-CODE16-NEXT:    jr nz, BB88_8
 ; EZ80-CODE16-NEXT:  ; %bb.7:
 ; EZ80-CODE16-NEXT:    lea bc, iy
@@ -15828,30 +15790,14 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld hl, 0
-; EZ80-CODE16-NEXT:    ld c, l
-; EZ80-CODE16-NEXT:    ld b, h
-; EZ80-CODE16-NEXT:    push bc
+; EZ80-CODE16-NEXT:    ex de, hl
+; EZ80-CODE16-NEXT:    push de
 ; EZ80-CODE16-NEXT:    lea hl, iy
-; EZ80-CODE16-NEXT:    ld e, c
-; EZ80-CODE16-NEXT:    ld d, b
+; EZ80-CODE16-NEXT:    ld c, e
+; EZ80-CODE16-NEXT:    ld b, d
 ; EZ80-CODE16-NEXT:    call __llsub
 ; EZ80-CODE16-NEXT:    ld (ix - 12), hl
 ; EZ80-CODE16-NEXT:    ld hl, 10
-; EZ80-CODE16-NEXT:    add hl, sp
-; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld hl, 31
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 20)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 14)
-; EZ80-CODE16-NEXT:    ld de, (ix - 16)
-; EZ80-CODE16-NEXT:    ld bc, (ix - 18)
-; EZ80-CODE16-NEXT:    call __llshl
-; EZ80-CODE16-NEXT:    ld (ix - 14), hl
-; EZ80-CODE16-NEXT:    ld (ix - 16), de
-; EZ80-CODE16-NEXT:    ld (ix - 18), bc
-; EZ80-CODE16-NEXT:    ld (ix - 20), iy
-; EZ80-CODE16-NEXT:    ld hl, 4
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
@@ -15926,19 +15872,34 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    call __llshrs
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
+; EZ80-CODE16-NEXT:    ld (ix - 4), de
+; EZ80-CODE16-NEXT:    ld (ix - 6), bc
+; EZ80-CODE16-NEXT:    ld (ix - 8), iy
 ; EZ80-CODE16-NEXT:    ld hl, 4
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    push iy
-; EZ80-CODE16-NEXT:    push bc
-; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    ld hl, 31
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 24)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 18)
+; EZ80-CODE16-NEXT:    ld de, (ix - 20)
+; EZ80-CODE16-NEXT:    ld bc, (ix - 22)
+; EZ80-CODE16-NEXT:    call __llshl
+; EZ80-CODE16-NEXT:    ld (ix - 10), hl
+; EZ80-CODE16-NEXT:    ld hl, 4
+; EZ80-CODE16-NEXT:    add hl, sp
+; EZ80-CODE16-NEXT:    ld sp, hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 6)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 4)
+; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 20)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 14)
-; EZ80-CODE16-NEXT:    ld de, (ix - 16)
-; EZ80-CODE16-NEXT:    ld bc, (ix - 18)
+; EZ80-CODE16-NEXT:    push iy
+; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
 ; EZ80-CODE16-NEXT:    call __lladd
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
 ; EZ80-CODE16-NEXT:    ld hl, 10
@@ -15954,7 +15915,7 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
-; EZ80-NEXT:    lea hl, ix - 24
+; EZ80-NEXT:    lea hl, ix - 33
 ; EZ80-NEXT:    ld sp, hl
 ; EZ80-NEXT:    ld bc, (ix + 12)
 ; EZ80-NEXT:    ld de, (ix + 15)
@@ -16003,49 +15964,58 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld de, (ix - 3)
 ; EZ80-NEXT:    ld bc, (ix - 6)
 ; EZ80-NEXT:    call __llxor
-; EZ80-NEXT:    ld iy, 9
-; EZ80-NEXT:    add iy, sp
-; EZ80-NEXT:    ld sp, iy
-; EZ80-NEXT:    ld iy, 0
-; EZ80-NEXT:    push iy
-; EZ80-NEXT:    ld iy, 64
-; EZ80-NEXT:    push iy
-; EZ80-NEXT:    ld iy, 0
-; EZ80-NEXT:    push iy
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld (ix - 24), de
+; EZ80-NEXT:    ld (ix - 27), bc
+; EZ80-NEXT:    ld hl, 9
+; EZ80-NEXT:    add hl, sp
+; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    lea hl, iy
+; EZ80-NEXT:    call __llctlz
+; EZ80-NEXT:    ld de, 0
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    ld l, a
+; EZ80-NEXT:    ld bc, -1
+; EZ80-NEXT:    push bc
+; EZ80-NEXT:    push bc
+; EZ80-NEXT:    push bc
+; EZ80-NEXT:    inc.sis bc
+; EZ80-NEXT:    call __lladd
+; EZ80-NEXT:    ld (ix - 9), hl
+; EZ80-NEXT:    ld (ix - 33), de
+; EZ80-NEXT:    ld (ix - 30), bc
+; EZ80-NEXT:    ld hl, 9
+; EZ80-NEXT:    add hl, sp
+; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    ld hl, 64
+; EZ80-NEXT:    ld de, 0
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    or a, a
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    lea hl, iy
+; EZ80-NEXT:    ld de, (ix - 24)
+; EZ80-NEXT:    ld bc, (ix - 27)
 ; EZ80-NEXT:    call __llcmpu
 ; EZ80-NEXT:    push af
 ; EZ80-NEXT:    ex (sp), hl
-; EZ80-NEXT:    ld (ix - 9), l
+; EZ80-NEXT:    ld (ix - 24), l
 ; EZ80-NEXT:    pop hl
-; EZ80-NEXT:    ld iy, 9
-; EZ80-NEXT:    add iy, sp
-; EZ80-NEXT:    ld sp, iy
+; EZ80-NEXT:    ld hl, 9
+; EZ80-NEXT:    add hl, sp
+; EZ80-NEXT:    ld sp, hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld l, (ix - 9)
+; EZ80-NEXT:    ld l, (ix - 24)
 ; EZ80-NEXT:    ; kill: def $h killed $a
 ; EZ80-NEXT:    ex (sp), hl
 ; EZ80-NEXT:    pop af
 ; EZ80-NEXT:    ccf
 ; EZ80-NEXT:    ; kill: def $a killed $a
 ; EZ80-NEXT:    sbc a, a
-; EZ80-NEXT:    ld iyl, a
-; EZ80-NEXT:    inc iyl
-; EZ80-NEXT:    call __llctlz
-; EZ80-NEXT:    or a, a
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld l, a
-; EZ80-NEXT:    ld a, iyl
-; EZ80-NEXT:    ld de, -1
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    inc de
-; EZ80-NEXT:    ld.sis bc, 0
-; EZ80-NEXT:    call __lladd
-; EZ80-NEXT:    ld (ix - 9), hl
-; EZ80-NEXT:    ld hl, 9
-; EZ80-NEXT:    add hl, sp
-; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    inc a
 ; EZ80-NEXT:    bit 0, a
 ; EZ80-NEXT:    jr z, BB88_2
 ; EZ80-NEXT:  ; %bb.1:
@@ -16054,26 +16024,29 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:  BB88_2:
 ; EZ80-NEXT:    bit 0, a
 ; EZ80-NEXT:    ld iy, 0
+; EZ80-NEXT:    lea bc, iy
 ; EZ80-NEXT:    jr nz, BB88_4
 ; EZ80-NEXT:  ; %bb.3:
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld bc, (ix - 33)
 ; EZ80-NEXT:  BB88_4:
 ; EZ80-NEXT:    bit 0, a
 ; EZ80-NEXT:    ld.sis de, 0
 ; EZ80-NEXT:    ; kill: def $de killed $de def $ude
 ; EZ80-NEXT:    jr nz, BB88_6
 ; EZ80-NEXT:  ; %bb.5:
-; EZ80-NEXT:    ld e, c
-; EZ80-NEXT:    ld d, b
+; EZ80-NEXT:    ld hl, (ix - 30)
+; EZ80-NEXT:    ld e, l
+; EZ80-NEXT:    ld d, h
 ; EZ80-NEXT:  BB88_6:
 ; EZ80-NEXT:    ld hl, 31
 ; EZ80-NEXT:    push de
-; EZ80-NEXT:    push iy
+; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    ld de, (ix - 9)
 ; EZ80-NEXT:    push de
-; EZ80-NEXT:    ld de, 0
-; EZ80-NEXT:    ld.sis bc, 0
+; EZ80-NEXT:    lea de, iy
+; EZ80-NEXT:    ld.sis iy, 0
+; EZ80-NEXT:    ld c, iyl
+; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    call __llsub
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop iy
@@ -16081,16 +16054,6 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld hl, 9
 ; EZ80-NEXT:    add hl, sp
 ; EZ80-NEXT:    ld sp, hl
-; EZ80-NEXT:    ld hl, 31
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld hl, (ix - 15)
-; EZ80-NEXT:    ld de, (ix - 18)
-; EZ80-NEXT:    ld bc, (ix - 21)
-; EZ80-NEXT:    call __llshl
-; EZ80-NEXT:    ld (ix - 15), hl
-; EZ80-NEXT:    ld (ix - 18), de
-; EZ80-NEXT:    ld (ix - 21), bc
-; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    ld hl, (ix - 9)
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix - 12)
@@ -16137,14 +16100,24 @@ define i64 @sdiv.fix.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld iy, (ix - 24)
 ; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    call __llshrs
+; EZ80-NEXT:    ld (ix - 3), hl
+; EZ80-NEXT:    ld (ix - 6), de
 ; EZ80-NEXT:    ; kill: def $bc killed $bc def $ubc
-; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    push de
+; EZ80-NEXT:    ld (ix - 9), bc
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    ld hl, 31
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix - 15)
 ; EZ80-NEXT:    ld de, (ix - 18)
 ; EZ80-NEXT:    ld bc, (ix - 21)
+; EZ80-NEXT:    call __llshl
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld iy, (ix - 9)
+; EZ80-NEXT:    push iy
+; EZ80-NEXT:    ld iy, (ix - 6)
+; EZ80-NEXT:    push iy
+; EZ80-NEXT:    ld iy, (ix - 3)
+; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    call __lladd
 ; EZ80-NEXT:    ld sp, ix
 ; EZ80-NEXT:    pop ix
@@ -16398,10 +16371,10 @@ define i32 @udiv.fix.i32.16(i32, i32) {
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld iy, (ix + 6)
 ; EZ80-NEXT:    ld a, (ix + 15)
+; EZ80-NEXT:    ld hl, 16
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    ld e, (ix + 9)
 ; EZ80-NEXT:    ld.sis bc, 0
-; EZ80-NEXT:    ld hl, 16
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    lea hl, iy
 ; EZ80-NEXT:    call __llshl
@@ -16502,10 +16475,10 @@ define i32 @udiv.fix.i32.32(i32, i32) {
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld iy, (ix + 6)
 ; EZ80-NEXT:    ld a, (ix + 15)
+; EZ80-NEXT:    ld hl, 32
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    ld e, (ix + 9)
 ; EZ80-NEXT:    ld.sis bc, 0
-; EZ80-NEXT:    ld hl, 32
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    lea hl, iy
 ; EZ80-NEXT:    call __llshl
@@ -16537,7 +16510,7 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; Z80-NEXT:    push ix
 ; Z80-NEXT:    ld ix, 0
 ; Z80-NEXT:    add ix, sp
-; Z80-NEXT:    ld hl, -20
+; Z80-NEXT:    ld hl, -26
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
 ; Z80-NEXT:    push hl
@@ -16565,12 +16538,12 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; Z80-NEXT:    ld c, (ix + 8)
 ; Z80-NEXT:    ld b, (ix + 9)
 ; Z80-NEXT:    call __lldivu
-; Z80-NEXT:    ld (ix - 12), l
-; Z80-NEXT:    ld (ix - 11), h
-; Z80-NEXT:    ld (ix - 14), e
-; Z80-NEXT:    ld (ix - 13), d
-; Z80-NEXT:    ld (ix - 16), c
-; Z80-NEXT:    ld (ix - 15), b
+; Z80-NEXT:    ld (ix - 14), l
+; Z80-NEXT:    ld (ix - 13), h
+; Z80-NEXT:    ld (ix - 16), e
+; Z80-NEXT:    ld (ix - 15), d
+; Z80-NEXT:    ld (ix - 18), c
+; Z80-NEXT:    ld (ix - 17), b
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    ex (sp), hl
 ; Z80-NEXT:    ld (ix - 20), l
@@ -16605,55 +16578,25 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; Z80-NEXT:    ld (ix - 1), h
 ; Z80-NEXT:    ld (ix - 4), e
 ; Z80-NEXT:    ld (ix - 3), d
+; Z80-NEXT:    ld (ix - 6), c
+; Z80-NEXT:    ld (ix - 5), b
 ; Z80-NEXT:    push iy
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 6), l
-; Z80-NEXT:    ld (ix - 5), h
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    ld hl, 10
-; Z80-NEXT:    add hl, sp
-; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    ld de, 0
-; Z80-NEXT:    push de
-; Z80-NEXT:    ld hl, 1
-; Z80-NEXT:    push hl
-; Z80-NEXT:    push de
-; Z80-NEXT:    push de
-; Z80-NEXT:    push iy
-; Z80-NEXT:    ld l, (ix - 2)
-; Z80-NEXT:    ld h, (ix - 1)
-; Z80-NEXT:    ld e, (ix - 4)
-; Z80-NEXT:    ld d, (ix - 3)
-; Z80-NEXT:    call __llcmpu
-; Z80-NEXT:    push af
 ; Z80-NEXT:    ex (sp), hl
 ; Z80-NEXT:    ld (ix - 8), l
+; Z80-NEXT:    ld (ix - 7), h
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 8)
-; Z80-NEXT:    ; kill: def $h killed $a
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    pop af
-; Z80-NEXT:    ccf
-; Z80-NEXT:    ; kill: def $a killed $a
-; Z80-NEXT:    sbc a, a
-; Z80-NEXT:    ld iyl, a
-; Z80-NEXT:    inc iyl
-; Z80-NEXT:    ld l, (ix - 6)
-; Z80-NEXT:    ld h, (ix - 5)
-; Z80-NEXT:    push hl
+; Z80-NEXT:    push iy
 ; Z80-NEXT:    ld l, (ix - 2)
 ; Z80-NEXT:    ld h, (ix - 1)
 ; Z80-NEXT:    ld e, (ix - 4)
 ; Z80-NEXT:    ld d, (ix - 3)
-; Z80-NEXT:    ld (ix - 18), c
-; Z80-NEXT:    ld (ix - 17), b
+; Z80-NEXT:    ld c, (ix - 6)
+; Z80-NEXT:    ld b, (ix - 5)
 ; Z80-NEXT:    call __llctlz
 ; Z80-NEXT:    ld l, a
-; Z80-NEXT:    ld a, iyl
 ; Z80-NEXT:    pop de
 ; Z80-NEXT:    ld h, 0
 ; Z80-NEXT:    ld bc, 0
@@ -16665,109 +16608,121 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; Z80-NEXT:    ld e, c
 ; Z80-NEXT:    ld d, b
 ; Z80-NEXT:    call __lladd
+; Z80-NEXT:    ld (ix - 26), l
+; Z80-NEXT:    ld (ix - 25), h
+; Z80-NEXT:    ld (ix - 12), e
+; Z80-NEXT:    ld (ix - 11), d
+; Z80-NEXT:    ld (ix - 24), c
+; Z80-NEXT:    ld (ix - 23), b
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 8), l
-; Z80-NEXT:    ld (ix - 7), h
+; Z80-NEXT:    ld (ix - 22), l
+; Z80-NEXT:    ld (ix - 21), h
 ; Z80-NEXT:    pop hl
-; Z80-NEXT:    ld iy, 10
-; Z80-NEXT:    add iy, sp
-; Z80-NEXT:    ld sp, iy
-; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld iy, 32
-; Z80-NEXT:    jr nz, BB94_2
-; Z80-NEXT:  ; %bb.1:
-; Z80-NEXT:    ex de, hl
-; Z80-NEXT:    ld iyl, e
-; Z80-NEXT:    ld iyh, d
-; Z80-NEXT:    ex de, hl
-; Z80-NEXT:  BB94_2:
-; Z80-NEXT:    push iy
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 10), l
-; Z80-NEXT:    ld (ix - 9), h
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld iy, 0
-; Z80-NEXT:    ex de, hl
-; Z80-NEXT:    ld e, iyl
-; Z80-NEXT:    ld d, iyh
-; Z80-NEXT:    ex de, hl
-; Z80-NEXT:    jr nz, BB94_4
-; Z80-NEXT:  ; %bb.3:
-; Z80-NEXT:    ex de, hl
-; Z80-NEXT:  BB94_4:
-; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld e, iyl
-; Z80-NEXT:    ld d, iyh
-; Z80-NEXT:    jr nz, BB94_6
-; Z80-NEXT:  ; %bb.5:
-; Z80-NEXT:    ld e, c
-; Z80-NEXT:    ld d, b
-; Z80-NEXT:  BB94_6:
-; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld c, iyl
-; Z80-NEXT:    ld b, iyh
-; Z80-NEXT:    jr nz, BB94_8
-; Z80-NEXT:  ; %bb.7:
-; Z80-NEXT:    ld c, (ix - 8)
-; Z80-NEXT:    ld b, (ix - 7)
-; Z80-NEXT:  BB94_8:
-; Z80-NEXT:    push bc
-; Z80-NEXT:    push de
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 10)
-; Z80-NEXT:    ld h, (ix - 9)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    push iy
-; Z80-NEXT:    ld hl, 32
-; Z80-NEXT:    ld e, iyl
-; Z80-NEXT:    ld d, iyh
-; Z80-NEXT:    ld c, iyl
-; Z80-NEXT:    ld b, iyh
-; Z80-NEXT:    call __llsub
-; Z80-NEXT:    ld (ix - 8), l
-; Z80-NEXT:    ld (ix - 7), h
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    ld hl, 32
+; Z80-NEXT:    ld iy, 32
+; Z80-NEXT:    ld hl, 1
+; Z80-NEXT:    ld de, 0
+; Z80-NEXT:    push de
 ; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 20)
-; Z80-NEXT:    ld h, (ix - 19)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 12)
-; Z80-NEXT:    ld h, (ix - 11)
-; Z80-NEXT:    ld e, (ix - 14)
-; Z80-NEXT:    ld d, (ix - 13)
-; Z80-NEXT:    ld c, (ix - 16)
-; Z80-NEXT:    ld b, (ix - 15)
-; Z80-NEXT:    call __llshl
-; Z80-NEXT:    ld (ix - 12), l
-; Z80-NEXT:    ld (ix - 11), h
-; Z80-NEXT:    ld (ix - 14), e
-; Z80-NEXT:    ld (ix - 13), d
-; Z80-NEXT:    ld (ix - 16), c
-; Z80-NEXT:    ld (ix - 15), b
-; Z80-NEXT:    push iy
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 20), l
-; Z80-NEXT:    ld (ix - 19), h
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    ld l, (ix - 10)
-; Z80-NEXT:    ld h, (ix - 9)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 6)
-; Z80-NEXT:    ld h, (ix - 5)
+; Z80-NEXT:    push de
+; Z80-NEXT:    push de
+; Z80-NEXT:    ld l, (ix - 8)
+; Z80-NEXT:    ld h, (ix - 7)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld l, (ix - 2)
 ; Z80-NEXT:    ld h, (ix - 1)
 ; Z80-NEXT:    ld e, (ix - 4)
 ; Z80-NEXT:    ld d, (ix - 3)
-; Z80-NEXT:    ld c, (ix - 18)
-; Z80-NEXT:    ld b, (ix - 17)
+; Z80-NEXT:    ld c, (ix - 6)
+; Z80-NEXT:    ld b, (ix - 5)
+; Z80-NEXT:    call __llcmpu
+; Z80-NEXT:    push af
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    ld (ix - 10), l
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld hl, 10
+; Z80-NEXT:    add hl, sp
+; Z80-NEXT:    ld sp, hl
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 10)
+; Z80-NEXT:    ; kill: def $h killed $a
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    pop af
+; Z80-NEXT:    ccf
+; Z80-NEXT:    ; kill: def $a killed $a
+; Z80-NEXT:    sbc a, a
+; Z80-NEXT:    inc a
+; Z80-NEXT:    bit 0, a
+; Z80-NEXT:    ex de, hl
+; Z80-NEXT:    ld e, iyl
+; Z80-NEXT:    ld d, iyh
+; Z80-NEXT:    ex de, hl
+; Z80-NEXT:    jr nz, BB94_2
+; Z80-NEXT:  ; %bb.1:
+; Z80-NEXT:    ld l, (ix - 26)
+; Z80-NEXT:    ld h, (ix - 25)
+; Z80-NEXT:  BB94_2:
+; Z80-NEXT:    bit 0, a
+; Z80-NEXT:    ld bc, 0
+; Z80-NEXT:    ld iyl, c
+; Z80-NEXT:    ld iyh, b
+; Z80-NEXT:    jr nz, BB94_4
+; Z80-NEXT:  ; %bb.3:
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    pop iy
+; Z80-NEXT:  BB94_4:
+; Z80-NEXT:    ld (ix - 12), l
+; Z80-NEXT:    ld (ix - 11), h
+; Z80-NEXT:    bit 0, a
+; Z80-NEXT:    ld e, c
+; Z80-NEXT:    ld d, b
+; Z80-NEXT:    jr nz, BB94_6
+; Z80-NEXT:  ; %bb.5:
+; Z80-NEXT:    ld e, (ix - 24)
+; Z80-NEXT:    ld d, (ix - 23)
+; Z80-NEXT:  BB94_6:
+; Z80-NEXT:    bit 0, a
+; Z80-NEXT:    ld l, c
+; Z80-NEXT:    ld h, b
+; Z80-NEXT:    jr nz, BB94_8
+; Z80-NEXT:  ; %bb.7:
+; Z80-NEXT:    ld l, (ix - 22)
+; Z80-NEXT:    ld h, (ix - 21)
+; Z80-NEXT:  BB94_8:
+; Z80-NEXT:    push hl
+; Z80-NEXT:    push de
+; Z80-NEXT:    push iy
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    push bc
+; Z80-NEXT:    ld hl, 32
+; Z80-NEXT:    ld e, c
+; Z80-NEXT:    ld d, b
+; Z80-NEXT:    call __llsub
+; Z80-NEXT:    ld (ix - 10), l
+; Z80-NEXT:    ld (ix - 9), h
+; Z80-NEXT:    ld hl, 10
+; Z80-NEXT:    add hl, sp
+; Z80-NEXT:    ld sp, hl
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 8)
+; Z80-NEXT:    ld h, (ix - 7)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 2)
+; Z80-NEXT:    ld h, (ix - 1)
+; Z80-NEXT:    ld e, (ix - 4)
+; Z80-NEXT:    ld d, (ix - 3)
+; Z80-NEXT:    ld c, (ix - 6)
+; Z80-NEXT:    ld b, (ix - 5)
 ; Z80-NEXT:    call __llshl
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
@@ -16777,13 +16732,13 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; Z80-NEXT:    ld (ix - 5), b
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 10), l
-; Z80-NEXT:    ld (ix - 9), h
+; Z80-NEXT:    ld (ix - 8), l
+; Z80-NEXT:    ld (ix - 7), h
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    pop hl
-; Z80-NEXT:    ld l, (ix - 8)
-; Z80-NEXT:    ld h, (ix - 7)
+; Z80-NEXT:    ld l, (ix - 10)
+; Z80-NEXT:    ld h, (ix - 9)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld bc, 0
 ; Z80-NEXT:    push bc
@@ -16791,25 +16746,25 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; Z80-NEXT:    ld e, c
 ; Z80-NEXT:    ld d, b
 ; Z80-NEXT:    call __llshl
-; Z80-NEXT:    ld (ix - 18), l
-; Z80-NEXT:    ld (ix - 17), h
+; Z80-NEXT:    ld (ix - 12), l
+; Z80-NEXT:    ld (ix - 11), h
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    ld hl, 1
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    push iy
-; Z80-NEXT:    ld l, (ix - 18)
-; Z80-NEXT:    ld h, (ix - 17)
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
 ; Z80-NEXT:    call __llshru
-; Z80-NEXT:    ld (ix - 18), l
-; Z80-NEXT:    ld (ix - 17), h
+; Z80-NEXT:    ld (ix - 12), l
+; Z80-NEXT:    ld (ix - 11), h
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    push bc
 ; Z80-NEXT:    push de
-; Z80-NEXT:    ld l, (ix - 18)
-; Z80-NEXT:    ld h, (ix - 17)
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld l, (ix + 18)
 ; Z80-NEXT:    ld h, (ix + 19)
@@ -16821,19 +16776,19 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; Z80-NEXT:    ld c, (ix + 16)
 ; Z80-NEXT:    ld b, (ix + 17)
 ; Z80-NEXT:    call __lladd
-; Z80-NEXT:    ld (ix - 18), l
-; Z80-NEXT:    ld (ix - 17), h
+; Z80-NEXT:    ld (ix - 12), l
+; Z80-NEXT:    ld (ix - 11), h
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    push bc
 ; Z80-NEXT:    push de
-; Z80-NEXT:    ld l, (ix - 18)
-; Z80-NEXT:    ld h, (ix - 17)
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
 ; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 10)
-; Z80-NEXT:    ld h, (ix - 9)
+; Z80-NEXT:    ld l, (ix - 8)
+; Z80-NEXT:    ld h, (ix - 7)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld l, (ix - 2)
 ; Z80-NEXT:    ld h, (ix - 1)
@@ -16847,8 +16802,8 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    ld l, (ix - 8)
-; Z80-NEXT:    ld h, (ix - 7)
+; Z80-NEXT:    ld l, (ix - 10)
+; Z80-NEXT:    ld h, (ix - 9)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    ld l, (ix - 2)
@@ -16856,23 +16811,48 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; Z80-NEXT:    call __llshru
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld (ix - 4), e
+; Z80-NEXT:    ld (ix - 3), d
+; Z80-NEXT:    ld (ix - 6), c
+; Z80-NEXT:    ld (ix - 5), b
 ; Z80-NEXT:    push iy
-; Z80-NEXT:    push bc
-; Z80-NEXT:    push de
-; Z80-NEXT:    ld l, (ix - 2)
-; Z80-NEXT:    ld h, (ix - 1)
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    ld (ix - 8), l
+; Z80-NEXT:    ld (ix - 7), h
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld hl, 32
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld l, (ix - 20)
 ; Z80-NEXT:    ld h, (ix - 19)
 ; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 12)
-; Z80-NEXT:    ld h, (ix - 11)
-; Z80-NEXT:    ld e, (ix - 14)
-; Z80-NEXT:    ld d, (ix - 13)
-; Z80-NEXT:    ld c, (ix - 16)
-; Z80-NEXT:    ld b, (ix - 15)
+; Z80-NEXT:    ld l, (ix - 14)
+; Z80-NEXT:    ld h, (ix - 13)
+; Z80-NEXT:    ld e, (ix - 16)
+; Z80-NEXT:    ld d, (ix - 15)
+; Z80-NEXT:    ld c, (ix - 18)
+; Z80-NEXT:    ld b, (ix - 17)
+; Z80-NEXT:    call __llshl
+; Z80-NEXT:    ld (ix - 10), l
+; Z80-NEXT:    ld (ix - 9), h
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld l, (ix - 8)
+; Z80-NEXT:    ld h, (ix - 7)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 6)
+; Z80-NEXT:    ld h, (ix - 5)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 4)
+; Z80-NEXT:    ld h, (ix - 3)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 2)
+; Z80-NEXT:    ld h, (ix - 1)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    push iy
+; Z80-NEXT:    ld l, (ix - 10)
+; Z80-NEXT:    ld h, (ix - 9)
 ; Z80-NEXT:    call __lladd
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
@@ -16890,7 +16870,7 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    push ix
 ; EZ80-CODE16-NEXT:    ld ix, 0
 ; EZ80-CODE16-NEXT:    add ix, sp
-; EZ80-CODE16-NEXT:    lea hl, ix - 20
+; EZ80-CODE16-NEXT:    lea hl, ix - 26
 ; EZ80-CODE16-NEXT:    ld sp, hl
 ; EZ80-CODE16-NEXT:    ld iy, (ix + 12)
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 14)
@@ -16906,9 +16886,9 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld de, (ix + 6)
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 8)
 ; EZ80-CODE16-NEXT:    call __lldivu
-; EZ80-CODE16-NEXT:    ld (ix - 12), hl
-; EZ80-CODE16-NEXT:    ld (ix - 14), de
-; EZ80-CODE16-NEXT:    ld (ix - 16), bc
+; EZ80-CODE16-NEXT:    ld (ix - 14), hl
+; EZ80-CODE16-NEXT:    ld (ix - 16), de
+; EZ80-CODE16-NEXT:    ld (ix - 18), bc
 ; EZ80-CODE16-NEXT:    ld (ix - 20), iy
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
@@ -16929,45 +16909,17 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    call __llremu
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
 ; EZ80-CODE16-NEXT:    ld (ix - 4), de
-; EZ80-CODE16-NEXT:    ld (ix - 6), iy
+; EZ80-CODE16-NEXT:    ld (ix - 6), bc
+; EZ80-CODE16-NEXT:    ld (ix - 8), iy
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld de, 0
-; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    ld hl, 1
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    push de
 ; EZ80-CODE16-NEXT:    push iy
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    ld de, (ix - 4)
-; EZ80-CODE16-NEXT:    call __llcmpu
-; EZ80-CODE16-NEXT:    push af
-; EZ80-CODE16-NEXT:    ex (sp), hl
-; EZ80-CODE16-NEXT:    ld (ix - 8), l
-; EZ80-CODE16-NEXT:    pop hl
-; EZ80-CODE16-NEXT:    ld hl, 10
-; EZ80-CODE16-NEXT:    add hl, sp
-; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld l, (ix - 8)
-; EZ80-CODE16-NEXT:    ; kill: def $h killed $a
-; EZ80-CODE16-NEXT:    ex (sp), hl
-; EZ80-CODE16-NEXT:    pop af
-; EZ80-CODE16-NEXT:    ccf
-; EZ80-CODE16-NEXT:    ; kill: def $a killed $a
-; EZ80-CODE16-NEXT:    sbc a, a
-; EZ80-CODE16-NEXT:    ld iyl, a
-; EZ80-CODE16-NEXT:    inc iyl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 6)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
-; EZ80-CODE16-NEXT:    ld de, (ix - 4)
-; EZ80-CODE16-NEXT:    ld (ix - 18), bc
+; EZ80-CODE16-NEXT:    ld bc, (ix - 6)
 ; EZ80-CODE16-NEXT:    call __llctlz
 ; EZ80-CODE16-NEXT:    ld l, a
-; EZ80-CODE16-NEXT:    ld a, iyl
 ; EZ80-CODE16-NEXT:    pop de
 ; EZ80-CODE16-NEXT:    ld h, 0
 ; EZ80-CODE16-NEXT:    ld bc, 0
@@ -16979,85 +16931,101 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld e, c
 ; EZ80-CODE16-NEXT:    ld d, b
 ; EZ80-CODE16-NEXT:    call __lladd
-; EZ80-CODE16-NEXT:    ld (ix - 8), iy
-; EZ80-CODE16-NEXT:    ld iy, 10
-; EZ80-CODE16-NEXT:    add iy, sp
-; EZ80-CODE16-NEXT:    ld sp, iy
-; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    ld iy, 32
-; EZ80-CODE16-NEXT:    jr nz, BB94_2
-; EZ80-CODE16-NEXT:  ; %bb.1:
-; EZ80-CODE16-NEXT:    ex de, hl
-; EZ80-CODE16-NEXT:    ld iyl, e
-; EZ80-CODE16-NEXT:    ld iyh, d
-; EZ80-CODE16-NEXT:    ex de, hl
-; EZ80-CODE16-NEXT:  BB94_2:
-; EZ80-CODE16-NEXT:    ld (ix - 10), iy
-; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    ld iy, 0
-; EZ80-CODE16-NEXT:    lea hl, iy
-; EZ80-CODE16-NEXT:    jr nz, BB94_4
-; EZ80-CODE16-NEXT:  ; %bb.3:
-; EZ80-CODE16-NEXT:    ex de, hl
-; EZ80-CODE16-NEXT:  BB94_4:
-; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    lea de, iy
-; EZ80-CODE16-NEXT:    jr nz, BB94_6
-; EZ80-CODE16-NEXT:  ; %bb.5:
-; EZ80-CODE16-NEXT:    ld e, c
-; EZ80-CODE16-NEXT:    ld d, b
-; EZ80-CODE16-NEXT:  BB94_6:
-; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    lea bc, iy
-; EZ80-CODE16-NEXT:    jr nz, BB94_8
-; EZ80-CODE16-NEXT:  ; %bb.7:
-; EZ80-CODE16-NEXT:    ld bc, (ix - 8)
-; EZ80-CODE16-NEXT:  BB94_8:
-; EZ80-CODE16-NEXT:    push bc
-; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    push iy
-; EZ80-CODE16-NEXT:    ld hl, 32
-; EZ80-CODE16-NEXT:    lea de, iy
-; EZ80-CODE16-NEXT:    lea bc, iy
-; EZ80-CODE16-NEXT:    call __llsub
-; EZ80-CODE16-NEXT:    ld (ix - 8), hl
+; EZ80-CODE16-NEXT:    ld (ix - 26), hl
+; EZ80-CODE16-NEXT:    ld (ix - 12), de
+; EZ80-CODE16-NEXT:    ld (ix - 24), bc
+; EZ80-CODE16-NEXT:    ld (ix - 22), iy
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld hl, 32
+; EZ80-CODE16-NEXT:    ld iy, 32
+; EZ80-CODE16-NEXT:    ld hl, 1
+; EZ80-CODE16-NEXT:    ld de, 0
+; EZ80-CODE16-NEXT:    push de
 ; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 20)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
-; EZ80-CODE16-NEXT:    ld de, (ix - 14)
-; EZ80-CODE16-NEXT:    ld bc, (ix - 16)
-; EZ80-CODE16-NEXT:    call __llshl
-; EZ80-CODE16-NEXT:    ld (ix - 12), hl
-; EZ80-CODE16-NEXT:    ld (ix - 14), de
-; EZ80-CODE16-NEXT:    ld (ix - 16), bc
-; EZ80-CODE16-NEXT:    ld (ix - 20), iy
-; EZ80-CODE16-NEXT:    ld hl, 4
-; EZ80-CODE16-NEXT:    add hl, sp
-; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 6)
+; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    ld de, (ix - 4)
-; EZ80-CODE16-NEXT:    ld bc, (ix - 18)
+; EZ80-CODE16-NEXT:    ld bc, (ix - 6)
+; EZ80-CODE16-NEXT:    call __llcmpu
+; EZ80-CODE16-NEXT:    push af
+; EZ80-CODE16-NEXT:    ex (sp), hl
+; EZ80-CODE16-NEXT:    ld (ix - 10), l
+; EZ80-CODE16-NEXT:    pop hl
+; EZ80-CODE16-NEXT:    ld hl, 10
+; EZ80-CODE16-NEXT:    add hl, sp
+; EZ80-CODE16-NEXT:    ld sp, hl
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld l, (ix - 10)
+; EZ80-CODE16-NEXT:    ; kill: def $h killed $a
+; EZ80-CODE16-NEXT:    ex (sp), hl
+; EZ80-CODE16-NEXT:    pop af
+; EZ80-CODE16-NEXT:    ccf
+; EZ80-CODE16-NEXT:    ; kill: def $a killed $a
+; EZ80-CODE16-NEXT:    sbc a, a
+; EZ80-CODE16-NEXT:    inc a
+; EZ80-CODE16-NEXT:    bit 0, a
+; EZ80-CODE16-NEXT:    lea hl, iy
+; EZ80-CODE16-NEXT:    jr nz, BB94_2
+; EZ80-CODE16-NEXT:  ; %bb.1:
+; EZ80-CODE16-NEXT:    ld hl, (ix - 26)
+; EZ80-CODE16-NEXT:  BB94_2:
+; EZ80-CODE16-NEXT:    bit 0, a
+; EZ80-CODE16-NEXT:    ld bc, 0
+; EZ80-CODE16-NEXT:    ld iyl, c
+; EZ80-CODE16-NEXT:    ld iyh, b
+; EZ80-CODE16-NEXT:    jr nz, BB94_4
+; EZ80-CODE16-NEXT:  ; %bb.3:
+; EZ80-CODE16-NEXT:    ld iy, (ix - 12)
+; EZ80-CODE16-NEXT:  BB94_4:
+; EZ80-CODE16-NEXT:    ld (ix - 12), hl
+; EZ80-CODE16-NEXT:    bit 0, a
+; EZ80-CODE16-NEXT:    ld e, c
+; EZ80-CODE16-NEXT:    ld d, b
+; EZ80-CODE16-NEXT:    jr nz, BB94_6
+; EZ80-CODE16-NEXT:  ; %bb.5:
+; EZ80-CODE16-NEXT:    ld de, (ix - 24)
+; EZ80-CODE16-NEXT:  BB94_6:
+; EZ80-CODE16-NEXT:    bit 0, a
+; EZ80-CODE16-NEXT:    ld l, c
+; EZ80-CODE16-NEXT:    ld h, b
+; EZ80-CODE16-NEXT:    jr nz, BB94_8
+; EZ80-CODE16-NEXT:  ; %bb.7:
+; EZ80-CODE16-NEXT:    ld hl, (ix - 22)
+; EZ80-CODE16-NEXT:  BB94_8:
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    push iy
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    push bc
+; EZ80-CODE16-NEXT:    ld hl, 32
+; EZ80-CODE16-NEXT:    ld e, c
+; EZ80-CODE16-NEXT:    ld d, b
+; EZ80-CODE16-NEXT:    call __llsub
+; EZ80-CODE16-NEXT:    ld (ix - 10), hl
+; EZ80-CODE16-NEXT:    ld hl, 10
+; EZ80-CODE16-NEXT:    add hl, sp
+; EZ80-CODE16-NEXT:    ld sp, hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
+; EZ80-CODE16-NEXT:    ld de, (ix - 4)
+; EZ80-CODE16-NEXT:    ld bc, (ix - 6)
 ; EZ80-CODE16-NEXT:    call __llshl
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
 ; EZ80-CODE16-NEXT:    ld (ix - 4), de
 ; EZ80-CODE16-NEXT:    ld (ix - 6), bc
-; EZ80-CODE16-NEXT:    ld (ix - 10), iy
+; EZ80-CODE16-NEXT:    ld (ix - 8), iy
 ; EZ80-CODE16-NEXT:    ld hl, 4
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld bc, 0
 ; EZ80-CODE16-NEXT:    push bc
@@ -17065,23 +17033,23 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld e, c
 ; EZ80-CODE16-NEXT:    ld d, b
 ; EZ80-CODE16-NEXT:    call __llshl
-; EZ80-CODE16-NEXT:    ld (ix - 18), hl
+; EZ80-CODE16-NEXT:    ld (ix - 12), hl
 ; EZ80-CODE16-NEXT:    ld hl, 4
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
 ; EZ80-CODE16-NEXT:    ld hl, 1
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    push iy
-; EZ80-CODE16-NEXT:    ld hl, (ix - 18)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
 ; EZ80-CODE16-NEXT:    call __llshru
-; EZ80-CODE16-NEXT:    ld (ix - 18), hl
+; EZ80-CODE16-NEXT:    ld (ix - 12), hl
 ; EZ80-CODE16-NEXT:    ld hl, 4
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
 ; EZ80-CODE16-NEXT:    push iy
 ; EZ80-CODE16-NEXT:    push bc
 ; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    ld hl, (ix - 18)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 18)
 ; EZ80-CODE16-NEXT:    push hl
@@ -17089,16 +17057,16 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld de, (ix + 14)
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 16)
 ; EZ80-CODE16-NEXT:    call __lladd
-; EZ80-CODE16-NEXT:    ld (ix - 18), hl
+; EZ80-CODE16-NEXT:    ld (ix - 12), hl
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
 ; EZ80-CODE16-NEXT:    push iy
 ; EZ80-CODE16-NEXT:    push bc
 ; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    ld hl, (ix - 18)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
 ; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    ld de, (ix - 4)
@@ -17108,25 +17076,40 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    push iy
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    call __llshru
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
+; EZ80-CODE16-NEXT:    ld (ix - 4), de
+; EZ80-CODE16-NEXT:    ld (ix - 6), bc
+; EZ80-CODE16-NEXT:    ld (ix - 8), iy
 ; EZ80-CODE16-NEXT:    ld hl, 4
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    push iy
-; EZ80-CODE16-NEXT:    push bc
-; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
+; EZ80-CODE16-NEXT:    ld hl, 32
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 20)
 ; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
-; EZ80-CODE16-NEXT:    ld de, (ix - 14)
-; EZ80-CODE16-NEXT:    ld bc, (ix - 16)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 14)
+; EZ80-CODE16-NEXT:    ld de, (ix - 16)
+; EZ80-CODE16-NEXT:    ld bc, (ix - 18)
+; EZ80-CODE16-NEXT:    call __llshl
+; EZ80-CODE16-NEXT:    ld (ix - 10), hl
+; EZ80-CODE16-NEXT:    ld hl, 4
+; EZ80-CODE16-NEXT:    add hl, sp
+; EZ80-CODE16-NEXT:    ld sp, hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 6)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 4)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    push iy
+; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
 ; EZ80-CODE16-NEXT:    call __lladd
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
 ; EZ80-CODE16-NEXT:    ld hl, 10
@@ -17142,7 +17125,7 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
-; EZ80-NEXT:    lea hl, ix - 21
+; EZ80-NEXT:    lea hl, ix - 30
 ; EZ80-NEXT:    ld sp, hl
 ; EZ80-NEXT:    ld bc, (ix + 12)
 ; EZ80-NEXT:    ld de, (ix + 15)
@@ -17173,106 +17156,102 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    call __llremu
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    ld (ix - 3), iy
+; EZ80-NEXT:    ld (ix - 3), de
+; EZ80-NEXT:    ld (ix - 6), bc
 ; EZ80-NEXT:    ld hl, 9
 ; EZ80-NEXT:    add hl, sp
 ; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    lea hl, iy
+; EZ80-NEXT:    call __llctlz
+; EZ80-NEXT:    ld de, 0
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    ld l, a
+; EZ80-NEXT:    ld bc, 0
+; EZ80-NEXT:    push bc
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    call __lladd
+; EZ80-NEXT:    ld (ix - 30), hl
+; EZ80-NEXT:    ld (ix - 27), de
+; EZ80-NEXT:    ld (ix - 24), bc
+; EZ80-NEXT:    ld hl, 9
+; EZ80-NEXT:    add hl, sp
+; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    ld hl, 256
+; EZ80-NEXT:    ld de, 0
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    or a, a
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld hl, 256
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    push hl
+; EZ80-NEXT:    ld (ix - 18), iy
 ; EZ80-NEXT:    lea hl, iy
+; EZ80-NEXT:    ld de, (ix - 3)
+; EZ80-NEXT:    ld bc, (ix - 6)
 ; EZ80-NEXT:    call __llcmpu
 ; EZ80-NEXT:    push af
 ; EZ80-NEXT:    ex (sp), hl
-; EZ80-NEXT:    ld (ix - 6), l
+; EZ80-NEXT:    ld (ix - 21), l
 ; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    ld hl, 9
 ; EZ80-NEXT:    add hl, sp
 ; EZ80-NEXT:    ld sp, hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld l, (ix - 6)
+; EZ80-NEXT:    ld l, (ix - 21)
 ; EZ80-NEXT:    ; kill: def $h killed $a
 ; EZ80-NEXT:    ex (sp), hl
 ; EZ80-NEXT:    pop af
 ; EZ80-NEXT:    ccf
 ; EZ80-NEXT:    ; kill: def $a killed $a
 ; EZ80-NEXT:    sbc a, a
-; EZ80-NEXT:    ld iyl, a
-; EZ80-NEXT:    inc iyl
-; EZ80-NEXT:    ld hl, (ix - 3)
-; EZ80-NEXT:    ld (ix - 18), de
-; EZ80-NEXT:    ld (ix - 21), bc
-; EZ80-NEXT:    call __llctlz
-; EZ80-NEXT:    or a, a
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld l, a
-; EZ80-NEXT:    ld a, iyl
-; EZ80-NEXT:    ld de, 0
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    ld.sis bc, 0
-; EZ80-NEXT:    call __lladd
-; EZ80-NEXT:    ld iy, 9
-; EZ80-NEXT:    add iy, sp
-; EZ80-NEXT:    ld sp, iy
+; EZ80-NEXT:    inc a
 ; EZ80-NEXT:    bit 0, a
 ; EZ80-NEXT:    ld iy, 32
+; EZ80-NEXT:    lea bc, iy
 ; EZ80-NEXT:    jr nz, BB94_2
 ; EZ80-NEXT:  ; %bb.1:
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld iy, (ix - 30)
 ; EZ80-NEXT:  BB94_2:
 ; EZ80-NEXT:    bit 0, a
 ; EZ80-NEXT:    ld hl, 0
 ; EZ80-NEXT:    jr nz, BB94_4
 ; EZ80-NEXT:  ; %bb.3:
-; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld hl, (ix - 27)
 ; EZ80-NEXT:  BB94_4:
 ; EZ80-NEXT:    bit 0, a
 ; EZ80-NEXT:    ld.sis de, 0
 ; EZ80-NEXT:    ; kill: def $de killed $de def $ude
-; EZ80-NEXT:    jr nz, BB94_6
+; EZ80-NEXT:    jp nz, BB94_6
 ; EZ80-NEXT:  ; %bb.5:
-; EZ80-NEXT:    ld e, c
-; EZ80-NEXT:    ld d, b
+; EZ80-NEXT:    ld de, (ix - 24)
+; EZ80-NEXT:    ; kill: def $de killed $de def $ude
 ; EZ80-NEXT:  BB94_6:
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    push iy
-; EZ80-NEXT:    ld hl, 32
+; EZ80-NEXT:    push bc
+; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    ld.sis bc, 0
 ; EZ80-NEXT:    call __llsub
-; EZ80-NEXT:    ld (ix - 6), hl
+; EZ80-NEXT:    lea de, iy
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld (ix - 21), iy
 ; EZ80-NEXT:    ld hl, 9
 ; EZ80-NEXT:    add hl, sp
 ; EZ80-NEXT:    ld sp, hl
-; EZ80-NEXT:    ld hl, 32
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld hl, (ix - 9)
-; EZ80-NEXT:    ld de, (ix - 12)
-; EZ80-NEXT:    ld bc, (ix - 15)
-; EZ80-NEXT:    call __llshl
-; EZ80-NEXT:    ld (ix - 9), hl
-; EZ80-NEXT:    ld (ix - 12), de
-; EZ80-NEXT:    ld (ix - 15), bc
-; EZ80-NEXT:    pop hl
-; EZ80-NEXT:    push iy
-; EZ80-NEXT:    ld hl, (ix - 3)
-; EZ80-NEXT:    ld de, (ix - 18)
-; EZ80-NEXT:    ld bc, (ix - 21)
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    ld hl, (ix - 18)
+; EZ80-NEXT:    ld de, (ix - 3)
+; EZ80-NEXT:    ld bc, (ix - 6)
 ; EZ80-NEXT:    call __llshl
 ; EZ80-NEXT:    ld (ix - 3), hl
-; EZ80-NEXT:    ld (ix - 18), de
-; EZ80-NEXT:    ld (ix - 21), bc
+; EZ80-NEXT:    ld (ix - 6), de
+; EZ80-NEXT:    ld (ix - 18), bc
 ; EZ80-NEXT:    pop hl
-; EZ80-NEXT:    ld hl, (ix - 6)
-; EZ80-NEXT:    push hl
+; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    ld hl, 1
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    ld.sis bc, 0
@@ -17299,23 +17278,33 @@ define i64 @udiv.fix.i64.32(i64, i64) {
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix - 3)
-; EZ80-NEXT:    ld de, (ix - 18)
-; EZ80-NEXT:    ld bc, (ix - 21)
+; EZ80-NEXT:    ld de, (ix - 6)
+; EZ80-NEXT:    ld bc, (ix - 18)
 ; EZ80-NEXT:    call __lldivu
 ; EZ80-NEXT:    ld iy, 9
 ; EZ80-NEXT:    add iy, sp
 ; EZ80-NEXT:    ld sp, iy
-; EZ80-NEXT:    ld iy, (ix - 6)
+; EZ80-NEXT:    ld iy, (ix - 21)
 ; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    call __llshru
+; EZ80-NEXT:    ld (ix - 3), hl
+; EZ80-NEXT:    ld (ix - 6), de
 ; EZ80-NEXT:    ; kill: def $bc killed $bc def $ubc
-; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    push de
+; EZ80-NEXT:    ld (ix - 18), bc
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    ld hl, 32
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix - 9)
 ; EZ80-NEXT:    ld de, (ix - 12)
 ; EZ80-NEXT:    ld bc, (ix - 15)
+; EZ80-NEXT:    call __llshl
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld iy, (ix - 18)
+; EZ80-NEXT:    push iy
+; EZ80-NEXT:    ld iy, (ix - 6)
+; EZ80-NEXT:    push iy
+; EZ80-NEXT:    ld iy, (ix - 3)
+; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    call __lladd
 ; EZ80-NEXT:    ld sp, ix
 ; EZ80-NEXT:    pop ix

--- a/llvm/test/CodeGen/Z80/intrinsics24.ll
+++ b/llvm/test/CodeGen/Z80/intrinsics24.ll
@@ -556,7 +556,6 @@ define i24 @usub.sat.i24(i24, i24) {
 ; EZ80-NEXT:    ld bc, 0
 ; EZ80-NEXT:    or a, a
 ; EZ80-NEXT:    ld hl, (ix + 6)
-; EZ80-NEXT:    ld de, (ix + 9)
 ; EZ80-NEXT:    sbc hl, de
 ; EZ80-NEXT:    jr c, BB22_2
 ; EZ80-NEXT:  ; %bb.1:

--- a/llvm/test/CodeGen/Z80/memory.ll
+++ b/llvm/test/CodeGen/Z80/memory.ll
@@ -2121,8 +2121,6 @@ define void @store.p2i64(i64, i64 addrspace(2)*) {
 ; Z80-NEXT:    ld c, (ix + 10)
 ; Z80-NEXT:    ld b, (ix + 11)
 ; Z80-NEXT:    ld iyh, c
-; Z80-NEXT:    ld c, (ix + 10)
-; Z80-NEXT:    ld b, (ix + 11)
 ; Z80-NEXT:    ld (ix - 1), b ; 1-byte Folded Spill
 ; Z80-NEXT:    ld c, l
 ; Z80-NEXT:    out (c), a
@@ -2183,7 +2181,6 @@ define void @store.p2i64(i64, i64 addrspace(2)*) {
 ; EZ80-CODE16-NEXT:    ld iyl, iyh
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 10)
 ; EZ80-CODE16-NEXT:    ld iyh, c
-; EZ80-CODE16-NEXT:    ld bc, (ix + 10)
 ; EZ80-CODE16-NEXT:    ld (ix - 1), b ; 1-byte Folded Spill
 ; EZ80-CODE16-NEXT:    ld c, l
 ; EZ80-CODE16-NEXT:    out (c), a
@@ -2470,8 +2467,6 @@ define void @store.p2i64.1(i64) {
 ; Z80-NEXT:    ld e, (ix + 8)
 ; Z80-NEXT:    ld d, (ix + 9)
 ; Z80-NEXT:    ld (ix - 2), e ; 1-byte Folded Spill
-; Z80-NEXT:    ld e, (ix + 8)
-; Z80-NEXT:    ld d, (ix + 9)
 ; Z80-NEXT:    ld (ix - 3), d ; 1-byte Folded Spill
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld l, (ix + 10)
@@ -2482,11 +2477,6 @@ define void @store.p2i64.1(i64) {
 ; Z80-NEXT:    ld a, iyl
 ; Z80-NEXT:    ld (ix - 4), a ; 1-byte Folded Spill
 ; Z80-NEXT:    pop af
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix + 10)
-; Z80-NEXT:    ld h, (ix + 11)
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    pop iy
 ; Z80-NEXT:    push af
 ; Z80-NEXT:    ld a, iyh
 ; Z80-NEXT:    ld (ix - 1), a ; 1-byte Folded Spill
@@ -2551,14 +2541,12 @@ define void @store.p2i64.1(i64) {
 ; EZ80-CODE16-NEXT:    pop af
 ; EZ80-CODE16-NEXT:    ld de, (ix + 8)
 ; EZ80-CODE16-NEXT:    ld (ix - 2), e ; 1-byte Folded Spill
-; EZ80-CODE16-NEXT:    ld de, (ix + 8)
 ; EZ80-CODE16-NEXT:    ld (ix - 3), d ; 1-byte Folded Spill
 ; EZ80-CODE16-NEXT:    ld iy, (ix + 10)
 ; EZ80-CODE16-NEXT:    push af
 ; EZ80-CODE16-NEXT:    ld a, iyl
 ; EZ80-CODE16-NEXT:    ld (ix - 4), a ; 1-byte Folded Spill
 ; EZ80-CODE16-NEXT:    pop af
-; EZ80-CODE16-NEXT:    ld iy, (ix + 10)
 ; EZ80-CODE16-NEXT:    push af
 ; EZ80-CODE16-NEXT:    ld a, iyh
 ; EZ80-CODE16-NEXT:    ld (ix - 1), a ; 1-byte Folded Spill
@@ -2862,8 +2850,6 @@ define void @store.p3i64(i64, i64 addrspace(3)*) {
 ; Z80-NEXT:    ld l, (ix + 10)
 ; Z80-NEXT:    ld h, (ix + 11)
 ; Z80-NEXT:    ld (ix - 2), l ; 1-byte Folded Spill
-; Z80-NEXT:    ld l, (ix + 10)
-; Z80-NEXT:    ld h, (ix + 11)
 ; Z80-NEXT:    ld (ix - 1), h ; 1-byte Folded Spill
 ; Z80-NEXT:    ld c, iyl
 ; Z80-NEXT:    ld b, iyh
@@ -2945,11 +2931,9 @@ define void @store.p3i64(i64, i64 addrspace(3)*) {
 ; EZ80-CODE16-NEXT:    ld d, b
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 8)
 ; EZ80-CODE16-NEXT:    ld h, c
-; EZ80-CODE16-NEXT:    ld bc, (ix + 8)
 ; EZ80-CODE16-NEXT:    ld (ix - 3), b ; 1-byte Folded Spill
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 10)
 ; EZ80-CODE16-NEXT:    ld (ix - 2), c ; 1-byte Folded Spill
-; EZ80-CODE16-NEXT:    ld bc, (ix + 10)
 ; EZ80-CODE16-NEXT:    ld (ix - 1), b ; 1-byte Folded Spill
 ; EZ80-CODE16-NEXT:    lea bc, iy
 ; EZ80-CODE16-NEXT:    out (c), a
@@ -3221,8 +3205,6 @@ define void @store.p3i64.1(i64) {
 ; Z80-NEXT:    ld l, (ix + 10)
 ; Z80-NEXT:    ld h, (ix + 11)
 ; Z80-NEXT:    ld (ix - 2), l ; 1-byte Folded Spill
-; Z80-NEXT:    ld l, (ix + 10)
-; Z80-NEXT:    ld h, (ix + 11)
 ; Z80-NEXT:    ld (ix - 1), h ; 1-byte Folded Spill
 ; Z80-NEXT:    ld c, iyl
 ; Z80-NEXT:    ld b, iyh
@@ -3305,11 +3287,9 @@ define void @store.p3i64.1(i64) {
 ; EZ80-CODE16-NEXT:    ld d, b
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 8)
 ; EZ80-CODE16-NEXT:    ld h, c
-; EZ80-CODE16-NEXT:    ld bc, (ix + 8)
 ; EZ80-CODE16-NEXT:    ld (ix - 3), b ; 1-byte Folded Spill
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 10)
 ; EZ80-CODE16-NEXT:    ld (ix - 2), c ; 1-byte Folded Spill
-; EZ80-CODE16-NEXT:    ld bc, (ix + 10)
 ; EZ80-CODE16-NEXT:    ld (ix - 1), b ; 1-byte Folded Spill
 ; EZ80-CODE16-NEXT:    lea bc, iy
 ; EZ80-CODE16-NEXT:    out (c), a

--- a/llvm/test/CodeGen/Z80/saturation.ll
+++ b/llvm/test/CodeGen/Z80/saturation.ll
@@ -2418,8 +2418,6 @@ define i32 @sshl.sat.i32(i32, i32) {
 ; Z80-NEXT:    ld (ix - 3), h
 ; Z80-NEXT:    ld l, (ix + 4)
 ; Z80-NEXT:    ld h, (ix + 5)
-; Z80-NEXT:    ld e, (ix + 6)
-; Z80-NEXT:    ld d, (ix + 7)
 ; Z80-NEXT:    call __lcmpu
 ; Z80-NEXT:    jr nz, BB18_10
 ; Z80-NEXT:  ; %bb.9:
@@ -2502,7 +2500,6 @@ define i32 @sshl.sat.i32(i32, i32) {
 ; EZ80-CODE16-NEXT:  BB18_8:
 ; EZ80-CODE16-NEXT:    ld (ix - 4), hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 4)
-; EZ80-CODE16-NEXT:    ld de, (ix + 6)
 ; EZ80-CODE16-NEXT:    call __lcmpu
 ; EZ80-CODE16-NEXT:    jr nz, BB18_10
 ; EZ80-CODE16-NEXT:  ; %bb.9:
@@ -3033,7 +3030,6 @@ define i64 @sshl.sat.i64(i64, i64) {
 ; EZ80-NEXT:    ld hl, (ix - 6)
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix + 6)
-; EZ80-NEXT:    ld de, (ix + 9)
 ; EZ80-NEXT:    ld bc, (ix + 12)
 ; EZ80-NEXT:    ; kill: def $bc killed $bc killed $ubc
 ; EZ80-NEXT:    call __llcmpu
@@ -4248,19 +4244,19 @@ define i8 @smul.fix.sat.i8.7(i8, i8) {
 ; Z80:       ; %bb.0:
 ; Z80-NEXT:    ld iy, 0
 ; Z80-NEXT:    add iy, sp
-; Z80-NEXT:    ld c, (iy + 2)
-; Z80-NEXT:    ld d, (iy + 4)
+; Z80-NEXT:    ld d, (iy + 2)
+; Z80-NEXT:    ld l, (iy + 4)
 ; Z80-NEXT:    ld e, 7
-; Z80-NEXT:    ld a, c
-; Z80-NEXT:    rlc a
-; Z80-NEXT:    sbc a, a
-; Z80-NEXT:    ld h, a
-; Z80-NEXT:    ld l, c
-; Z80-NEXT:    ld a, d
+; Z80-NEXT:    ld a, l
 ; Z80-NEXT:    rlc a
 ; Z80-NEXT:    sbc a, a
 ; Z80-NEXT:    ld b, a
-; Z80-NEXT:    ld c, d
+; Z80-NEXT:    ld c, l
+; Z80-NEXT:    ld a, d
+; Z80-NEXT:    rlc a
+; Z80-NEXT:    sbc a, a
+; Z80-NEXT:    ld h, a
+; Z80-NEXT:    ld l, d
 ; Z80-NEXT:    call __smulu
 ; Z80-NEXT:    ld c, e
 ; Z80-NEXT:    call __sshrs
@@ -4293,19 +4289,19 @@ define i8 @smul.fix.sat.i8.7(i8, i8) {
 ; EZ80-CODE16:       ; %bb.0:
 ; EZ80-CODE16-NEXT:    ld iy, 0
 ; EZ80-CODE16-NEXT:    add iy, sp
-; EZ80-CODE16-NEXT:    ld c, (iy + 2)
-; EZ80-CODE16-NEXT:    ld d, (iy + 4)
+; EZ80-CODE16-NEXT:    ld d, (iy + 2)
+; EZ80-CODE16-NEXT:    ld l, (iy + 4)
 ; EZ80-CODE16-NEXT:    ld e, 7
-; EZ80-CODE16-NEXT:    ld a, c
-; EZ80-CODE16-NEXT:    rlc a
-; EZ80-CODE16-NEXT:    sbc a, a
-; EZ80-CODE16-NEXT:    ld h, a
-; EZ80-CODE16-NEXT:    ld l, c
-; EZ80-CODE16-NEXT:    ld a, d
+; EZ80-CODE16-NEXT:    ld a, l
 ; EZ80-CODE16-NEXT:    rlc a
 ; EZ80-CODE16-NEXT:    sbc a, a
 ; EZ80-CODE16-NEXT:    ld b, a
-; EZ80-CODE16-NEXT:    ld c, d
+; EZ80-CODE16-NEXT:    ld c, l
+; EZ80-CODE16-NEXT:    ld a, d
+; EZ80-CODE16-NEXT:    rlc a
+; EZ80-CODE16-NEXT:    sbc a, a
+; EZ80-CODE16-NEXT:    ld h, a
+; EZ80-CODE16-NEXT:    ld l, d
 ; EZ80-CODE16-NEXT:    call __smulu
 ; EZ80-CODE16-NEXT:    ld c, e
 ; EZ80-CODE16-NEXT:    call __sshrs
@@ -4338,19 +4334,19 @@ define i8 @smul.fix.sat.i8.7(i8, i8) {
 ; EZ80:       ; %bb.0:
 ; EZ80-NEXT:    ld iy, 0
 ; EZ80-NEXT:    add iy, sp
-; EZ80-NEXT:    ld c, (iy + 3)
-; EZ80-NEXT:    ld d, (iy + 6)
+; EZ80-NEXT:    ld d, (iy + 3)
+; EZ80-NEXT:    ld l, (iy + 6)
 ; EZ80-NEXT:    ld e, 7
-; EZ80-NEXT:    ld a, c
-; EZ80-NEXT:    rlc a
-; EZ80-NEXT:    sbc a, a
-; EZ80-NEXT:    ld h, a
-; EZ80-NEXT:    ld l, c
-; EZ80-NEXT:    ld a, d
+; EZ80-NEXT:    ld a, l
 ; EZ80-NEXT:    rlc a
 ; EZ80-NEXT:    sbc a, a
 ; EZ80-NEXT:    ld b, a
-; EZ80-NEXT:    ld c, d
+; EZ80-NEXT:    ld c, l
+; EZ80-NEXT:    ld a, d
+; EZ80-NEXT:    rlc a
+; EZ80-NEXT:    sbc a, a
+; EZ80-NEXT:    ld h, a
+; EZ80-NEXT:    ld l, d
 ; EZ80-NEXT:    call __smulu
 ; EZ80-NEXT:    ld c, e
 ; EZ80-NEXT:    call __sshrs
@@ -4552,42 +4548,42 @@ define i16 @smul.fix.sat.i16.7(i16, i16) {
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld bc, (ix + 6)
-; EZ80-NEXT:    ld a, b
-; EZ80-NEXT:    ld l, a
-; EZ80-NEXT:    rlc l
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    pop de
-; EZ80-NEXT:    ld d, a
-; EZ80-NEXT:    ld e, c
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop hl
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    add iy, iy
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld (ix - 3), hl
-; EZ80-NEXT:    ld iy, (ix + 9)
-; EZ80-NEXT:    ld a, iyh
+; EZ80-NEXT:    ld de, (ix + 9)
+; EZ80-NEXT:    ld a, d
 ; EZ80-NEXT:    ld l, a
 ; EZ80-NEXT:    rlc l
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop bc
 ; EZ80-NEXT:    ld b, a
-; EZ80-NEXT:    ld c, iyl
+; EZ80-NEXT:    ld c, e
 ; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    add iy, iy
 ; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ld (ix - 3), hl
+; EZ80-NEXT:    ld iy, (ix + 6)
+; EZ80-NEXT:    ld a, iyh
+; EZ80-NEXT:    ld l, a
+; EZ80-NEXT:    rlc l
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    pop de
+; EZ80-NEXT:    ld d, a
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    add iy, iy
+; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    ex de, hl
-; EZ80-NEXT:    ld de, (ix - 3)
-; EZ80-NEXT:    ; kill: def $e killed $e killed $ude
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    ld iy, (ix - 3)
 ; EZ80-NEXT:    ld a, iyl
 ; EZ80-NEXT:    call __lmulu
 ; EZ80-NEXT:    push hl
@@ -4812,42 +4808,42 @@ define i16 @smul.fix.sat.i16.15(i16, i16) {
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld bc, (ix + 6)
-; EZ80-NEXT:    ld a, b
-; EZ80-NEXT:    ld l, a
-; EZ80-NEXT:    rlc l
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    pop de
-; EZ80-NEXT:    ld d, a
-; EZ80-NEXT:    ld e, c
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop hl
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    add iy, iy
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld (ix - 3), hl
-; EZ80-NEXT:    ld iy, (ix + 9)
-; EZ80-NEXT:    ld a, iyh
+; EZ80-NEXT:    ld de, (ix + 9)
+; EZ80-NEXT:    ld a, d
 ; EZ80-NEXT:    ld l, a
 ; EZ80-NEXT:    rlc l
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop bc
 ; EZ80-NEXT:    ld b, a
-; EZ80-NEXT:    ld c, iyl
+; EZ80-NEXT:    ld c, e
 ; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    add iy, iy
 ; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ld (ix - 3), hl
+; EZ80-NEXT:    ld iy, (ix + 6)
+; EZ80-NEXT:    ld a, iyh
+; EZ80-NEXT:    ld l, a
+; EZ80-NEXT:    rlc l
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    pop de
+; EZ80-NEXT:    ld d, a
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    add iy, iy
+; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    ex de, hl
-; EZ80-NEXT:    ld de, (ix - 3)
-; EZ80-NEXT:    ; kill: def $e killed $e killed $ude
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    ld iy, (ix - 3)
 ; EZ80-NEXT:    ld a, iyl
 ; EZ80-NEXT:    call __lmulu
 ; EZ80-NEXT:    push hl
@@ -5059,7 +5055,6 @@ define i32 @smul.fix.sat.i32.15(i32, i32) {
 ; Z80-NEXT:    bit 0, a
 ; Z80-NEXT:    jp nz, BB35_5
 ; Z80-NEXT:  BB35_11:
-; Z80-NEXT:    ld de, -32768
 ; Z80-NEXT:    ld (ix - 2), e
 ; Z80-NEXT:    ld (ix - 1), d
 ; Z80-NEXT:    bit 0, a
@@ -5217,7 +5212,6 @@ define i32 @smul.fix.sat.i32.15(i32, i32) {
 ; EZ80-CODE16-NEXT:    bit 0, a
 ; EZ80-CODE16-NEXT:    jp nz, BB35_5
 ; EZ80-CODE16-NEXT:  BB35_11:
-; EZ80-CODE16-NEXT:    ld de, -32768
 ; EZ80-CODE16-NEXT:    ld (ix - 2), de
 ; EZ80-CODE16-NEXT:    bit 0, a
 ; EZ80-CODE16-NEXT:    jp nz, BB35_6
@@ -5253,8 +5247,8 @@ define i32 @smul.fix.sat.i32.15(i32, i32) {
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    lea hl, ix - 10
 ; EZ80-NEXT:    ld sp, hl
-; EZ80-NEXT:    ld e, (ix + 9)
-; EZ80-NEXT:    ld a, (ix + 15)
+; EZ80-NEXT:    ld a, (ix + 9)
+; EZ80-NEXT:    ld e, (ix + 15)
 ; EZ80-NEXT:    ld l, e
 ; EZ80-NEXT:    rlc l
 ; EZ80-NEXT:    sbc hl, hl
@@ -5281,14 +5275,15 @@ define i32 @smul.fix.sat.i32.15(i32, i32) {
 ; EZ80-NEXT:    add iy, iy
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld hl, (ix - 3)
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    ld hl, (ix + 12)
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix + 6)
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    pop de
-; EZ80-NEXT:    ld bc, (ix - 3)
-; EZ80-NEXT:    ; kill: def $bc killed $bc killed $ubc
+; EZ80-NEXT:    ld c, iyl
+; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    call __llmulu
 ; EZ80-NEXT:    ld iy, 9
 ; EZ80-NEXT:    add iy, sp
@@ -5565,7 +5560,6 @@ define i32 @smul.fix.sat.i32.31(i32, i32) {
 ; Z80-NEXT:    bit 0, a
 ; Z80-NEXT:    jp nz, BB36_5
 ; Z80-NEXT:  BB36_11:
-; Z80-NEXT:    ld de, -32768
 ; Z80-NEXT:    ld (ix - 2), e
 ; Z80-NEXT:    ld (ix - 1), d
 ; Z80-NEXT:    bit 0, a
@@ -5723,7 +5717,6 @@ define i32 @smul.fix.sat.i32.31(i32, i32) {
 ; EZ80-CODE16-NEXT:    bit 0, a
 ; EZ80-CODE16-NEXT:    jp nz, BB36_5
 ; EZ80-CODE16-NEXT:  BB36_11:
-; EZ80-CODE16-NEXT:    ld de, -32768
 ; EZ80-CODE16-NEXT:    ld (ix - 2), de
 ; EZ80-CODE16-NEXT:    bit 0, a
 ; EZ80-CODE16-NEXT:    jp nz, BB36_6
@@ -5759,8 +5752,8 @@ define i32 @smul.fix.sat.i32.31(i32, i32) {
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    lea hl, ix - 10
 ; EZ80-NEXT:    ld sp, hl
-; EZ80-NEXT:    ld e, (ix + 9)
-; EZ80-NEXT:    ld a, (ix + 15)
+; EZ80-NEXT:    ld a, (ix + 9)
+; EZ80-NEXT:    ld e, (ix + 15)
 ; EZ80-NEXT:    ld l, e
 ; EZ80-NEXT:    rlc l
 ; EZ80-NEXT:    sbc hl, hl
@@ -5787,14 +5780,15 @@ define i32 @smul.fix.sat.i32.31(i32, i32) {
 ; EZ80-NEXT:    add iy, iy
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld hl, (ix - 3)
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    ld hl, (ix + 12)
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix + 6)
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    pop de
-; EZ80-NEXT:    ld bc, (ix - 3)
-; EZ80-NEXT:    ; kill: def $bc killed $bc killed $ubc
+; EZ80-NEXT:    ld c, iyl
+; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    call __llmulu
 ; EZ80-NEXT:    ld iy, 9
 ; EZ80-NEXT:    add iy, sp
@@ -5970,13 +5964,6 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; Z80-NEXT:    ld h, (ix + 9)
 ; Z80-NEXT:    ld e, (ix + 10)
 ; Z80-NEXT:    ld d, (ix + 11)
-; Z80-NEXT:    ld c, (ix + 12)
-; Z80-NEXT:    ld b, (ix + 13)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix + 14)
-; Z80-NEXT:    ld h, (ix + 15)
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    pop iy
 ; Z80-NEXT:    call __lmulu
 ; Z80-NEXT:    ld (ix - 12), l
 ; Z80-NEXT:    ld (ix - 11), h
@@ -7034,8 +7021,6 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld (ix - 22), de
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 8)
 ; EZ80-CODE16-NEXT:    ld de, (ix + 10)
-; EZ80-CODE16-NEXT:    ld bc, (ix + 12)
-; EZ80-CODE16-NEXT:    ld iy, (ix + 14)
 ; EZ80-CODE16-NEXT:    call __lmulu
 ; EZ80-CODE16-NEXT:    ld (ix - 12), hl
 ; EZ80-CODE16-NEXT:    ld (ix - 2), de
@@ -7759,56 +7744,59 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld hl, -329
 ; EZ80-NEXT:    add hl, sp
 ; EZ80-NEXT:    ld sp, hl
-; EZ80-NEXT:    ld bc, -225
+; EZ80-NEXT:    ld de, -225
 ; EZ80-NEXT:    lea hl, ix
-; EZ80-NEXT:    add hl, bc
-; EZ80-NEXT:    ld bc, -237
+; EZ80-NEXT:    add hl, de
+; EZ80-NEXT:    ld de, -237
+; EZ80-NEXT:    lea iy, ix
+; EZ80-NEXT:    add iy, de
+; EZ80-NEXT:    ld (iy), hl
+; EZ80-NEXT:    ld bc, (ix + 9)
+; EZ80-NEXT:    ld de, (ix + 12)
+; EZ80-NEXT:    ld iy, (ix + 21)
+; EZ80-NEXT:    ld a, iyh
+; EZ80-NEXT:    ld l, a
+; EZ80-NEXT:    rlc l
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ld h, a
+; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld (ix - 3), bc
+; EZ80-NEXT:    ld bc, -243
 ; EZ80-NEXT:    lea iy, ix
 ; EZ80-NEXT:    add iy, bc
 ; EZ80-NEXT:    ld (iy), hl
-; EZ80-NEXT:    ld de, (ix + 12)
-; EZ80-NEXT:    ld bc, (ix + 21)
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    add iy, iy
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ld bc, -271
+; EZ80-NEXT:    lea iy, ix
+; EZ80-NEXT:    add iy, bc
+; EZ80-NEXT:    ld (iy), hl
 ; EZ80-NEXT:    ld a, d
 ; EZ80-NEXT:    ld l, a
 ; EZ80-NEXT:    rlc l
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    ld h, a
 ; EZ80-NEXT:    ld l, e
-; EZ80-NEXT:    ld (ix - 3), de
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld de, -246
-; EZ80-NEXT:    add ix, de
+; EZ80-NEXT:    ld bc, -246
+; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), hl
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    add iy, iy
 ; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld de, -249
+; EZ80-NEXT:    ld bc, -249
 ; EZ80-NEXT:    lea iy, ix
-; EZ80-NEXT:    add iy, de
+; EZ80-NEXT:    add iy, bc
 ; EZ80-NEXT:    ld (iy), hl
-; EZ80-NEXT:    ld a, b
-; EZ80-NEXT:    ld l, a
-; EZ80-NEXT:    rlc l
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld h, a
-; EZ80-NEXT:    ld l, c
-; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld de, -243
-; EZ80-NEXT:    add ix, de
-; EZ80-NEXT:    ld (ix), hl
-; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    add iy, iy
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld de, -271
-; EZ80-NEXT:    lea iy, ix
-; EZ80-NEXT:    add iy, de
-; EZ80-NEXT:    ld (iy), hl
-; EZ80-NEXT:    ld bc, (ix + 9)
+; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    ld a, c
+; EZ80-NEXT:    ld (ix - 3), de
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld de, -234
 ; EZ80-NEXT:    add ix, de
@@ -7828,8 +7816,8 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    ld (iy + 3), bc
 ; EZ80-NEXT:    ld.sis bc, (iy + 4)
-; EZ80-NEXT:    ld de, (ix - 3)
 ; EZ80-NEXT:    ld l, 31
+; EZ80-NEXT:    ld de, (ix - 3)
 ; EZ80-NEXT:    ld a, e
 ; EZ80-NEXT:    ld (ix - 3), de
 ; EZ80-NEXT:    push ix
@@ -7859,24 +7847,21 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld (ix), a ; 1-byte Folded Spill
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    ld de, (ix + 18)
-; EZ80-NEXT:    ld a, e
-; EZ80-NEXT:    ld (ix - 3), bc
+; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld a, l
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -231
-; EZ80-NEXT:    add ix, bc
+; EZ80-NEXT:    ld de, -231
+; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld (ix), a
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld (iy + 9), de
-; EZ80-NEXT:    ld bc, (ix - 3)
+; EZ80-NEXT:    ld (iy + 9), hl
 ; EZ80-NEXT:    ld.sis bc, (iy + 10)
-; EZ80-NEXT:    ld (ix - 3), de
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld de, -268
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld (ix), bc
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld de, (ix - 3)
-; EZ80-NEXT:    ld (iy + 12), de
+; EZ80-NEXT:    ld (iy + 12), hl
 ; EZ80-NEXT:    ld.sis de, (iy + 13)
 ; EZ80-NEXT:    ld hl, (ix + 21)
 ; EZ80-NEXT:    ld a, l
@@ -7934,9 +7919,6 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), de
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld hl, (ix + 9)
-; EZ80-NEXT:    ld (iy + 18), hl
-; EZ80-NEXT:    ld.sis hl, (iy + 19)
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -246
 ; EZ80-NEXT:    add ix, bc
@@ -7948,6 +7930,9 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), a
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld hl, (ix + 9)
+; EZ80-NEXT:    ld (iy + 18), hl
+; EZ80-NEXT:    ld.sis hl, (iy + 19)
 ; EZ80-NEXT:    ld (iy + 21), hl
 ; EZ80-NEXT:    ld (iy + 23), a
 ; EZ80-NEXT:    ld hl, (iy + 21)
@@ -7976,9 +7961,6 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), e ; 1-byte Folded Spill
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld hl, (ix + 18)
-; EZ80-NEXT:    ld (iy + 24), hl
-; EZ80-NEXT:    ld.sis hl, (iy + 25)
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -243
 ; EZ80-NEXT:    add ix, bc
@@ -7990,6 +7972,9 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), a
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld hl, (ix + 18)
+; EZ80-NEXT:    ld (iy + 24), hl
+; EZ80-NEXT:    ld.sis hl, (iy + 25)
 ; EZ80-NEXT:    ld (iy + 27), hl
 ; EZ80-NEXT:    ld (iy + 29), a
 ; EZ80-NEXT:    ld bc, (ix - 3)
@@ -8151,18 +8136,6 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld (ix), e ; 1-byte Folded Spill
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -237
-; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld iy, (ix)
-; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -246
-; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld hl, (ix)
-; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld (iy + 30), hl
-; EZ80-NEXT:    ld l, (iy + 32)
-; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -249
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld de, (ix)
@@ -8176,6 +8149,18 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld (ix), bc
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld de, -237
+; EZ80-NEXT:    add ix, de
+; EZ80-NEXT:    ld iy, (ix)
+; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld de, -246
+; EZ80-NEXT:    add ix, de
+; EZ80-NEXT:    ld hl, (ix)
+; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld (iy + 30), hl
+; EZ80-NEXT:    ld l, (iy + 32)
 ; EZ80-NEXT:    ld (iy + 33), hl
 ; EZ80-NEXT:    ld.sis (iy + 34), bc
 ; EZ80-NEXT:    ld hl, (iy + 33)
@@ -8249,13 +8234,6 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld (ix), e ; 1-byte Folded Spill
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -243
-; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld hl, (ix)
-; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld (iy + 51), hl
-; EZ80-NEXT:    ld l, (iy + 53)
-; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -271
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld de, (ix)
@@ -8269,6 +8247,13 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld (ix), bc
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld de, -243
+; EZ80-NEXT:    add ix, de
+; EZ80-NEXT:    ld hl, (ix)
+; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld (iy + 51), hl
+; EZ80-NEXT:    ld l, (iy + 53)
 ; EZ80-NEXT:    ld (iy + 54), hl
 ; EZ80-NEXT:    ld.sis (iy + 55), bc
 ; EZ80-NEXT:    ld bc, (iy + 54)
@@ -9012,7 +8997,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld h, e
 ; EZ80-NEXT:    ld (ix - 3), de
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld de, -234
+; EZ80-NEXT:    ld de, -231
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld (ix), hl
 ; EZ80-NEXT:    pop ix
@@ -9057,7 +9042,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    call __llshru
 ; EZ80-NEXT:    ld (ix - 3), bc
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -231
+; EZ80-NEXT:    ld bc, -234
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), hl
 ; EZ80-NEXT:    pop ix
@@ -9098,7 +9083,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld (ix - 120), iy
 ; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    ld (ix - 3), de
-; EZ80-NEXT:    ld de, -234
+; EZ80-NEXT:    ld de, -231
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, de
 ; EZ80-NEXT:    ld bc, (hl)
@@ -9119,7 +9104,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld bc, -231
+; EZ80-NEXT:    ld bc, -234
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
 ; EZ80-NEXT:    ld hl, (hl)
@@ -9137,12 +9122,12 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    call __llor
 ; EZ80-NEXT:    ld (ix - 3), bc
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -237
+; EZ80-NEXT:    ld bc, -234
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), hl
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -231
+; EZ80-NEXT:    ld bc, -237
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), de
 ; EZ80-NEXT:    pop ix
@@ -9175,7 +9160,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    ld (ix - 114), hl
 ; EZ80-NEXT:    ld (ix - 3), de
-; EZ80-NEXT:    ld de, -234
+; EZ80-NEXT:    ld de, -231
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, de
 ; EZ80-NEXT:    ld bc, (hl)
@@ -9190,12 +9175,12 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    call __llshrs
 ; EZ80-NEXT:    ld (ix - 3), bc
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -243
+; EZ80-NEXT:    ld bc, -246
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), hl
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -240
+; EZ80-NEXT:    ld bc, -243
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), de
 ; EZ80-NEXT:    pop ix
@@ -9203,7 +9188,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ; kill: def $bc killed $bc def $ubc
 ; EZ80-NEXT:    ld (ix - 3), de
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld de, -234
+; EZ80-NEXT:    ld de, -240
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld (ix), bc
 ; EZ80-NEXT:    pop ix
@@ -9212,10 +9197,10 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld de, (ix - 3)
 ; EZ80-NEXT:    ld de, -1
 ; EZ80-NEXT:    ld b, d
-; EZ80-NEXT:    ld (ix - 111), hl
-; EZ80-NEXT:    ld l, (ix - 109)
 ; EZ80-NEXT:    ld iyl, e
 ; EZ80-NEXT:    ld iyh, d
+; EZ80-NEXT:    ld (ix - 111), hl
+; EZ80-NEXT:    ld l, (ix - 109)
 ; EZ80-NEXT:    ld (ix - 108), hl
 ; EZ80-NEXT:    ld.sis (ix - 107), iy
 ; EZ80-NEXT:    ld hl, (ix - 108)
@@ -9233,11 +9218,6 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld (ix - 99), iy
 ; EZ80-NEXT:    ld c, (ix - 97)
 ; EZ80-NEXT:    ld (ix - 3), de
-; EZ80-NEXT:    ld de, -234
-; EZ80-NEXT:    lea iy, ix
-; EZ80-NEXT:    add iy, de
-; EZ80-NEXT:    ld iy, (iy)
-; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    ld de, -240
 ; EZ80-NEXT:    lea iy, ix
 ; EZ80-NEXT:    add iy, de
@@ -9249,6 +9229,11 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld iy, (iy)
 ; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    ld de, -246
+; EZ80-NEXT:    lea iy, ix
+; EZ80-NEXT:    add iy, de
+; EZ80-NEXT:    ld iy, (iy)
+; EZ80-NEXT:    push iy
+; EZ80-NEXT:    ld de, -231
 ; EZ80-NEXT:    lea iy, ix
 ; EZ80-NEXT:    add iy, de
 ; EZ80-NEXT:    ld (iy), bc
@@ -9314,7 +9299,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld de, (ix - 87)
 ; EZ80-NEXT:    ld (ix - 84), iy
 ; EZ80-NEXT:    ld (ix - 3), de
-; EZ80-NEXT:    ld de, -246
+; EZ80-NEXT:    ld de, -231
 ; EZ80-NEXT:    lea iy, ix
 ; EZ80-NEXT:    add iy, de
 ; EZ80-NEXT:    ld bc, (iy)
@@ -9327,18 +9312,18 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld de, (ix - 3)
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld bc, -243
+; EZ80-NEXT:    ld bc, -246
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -240
+; EZ80-NEXT:    ld bc, -243
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld de, (ix)
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    ld (ix - 3), de
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld de, -234
+; EZ80-NEXT:    ld de, -240
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld bc, (ix)
 ; EZ80-NEXT:    pop ix
@@ -9382,16 +9367,16 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    add hl, de
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld de, -231
+; EZ80-NEXT:    ld de, -237
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, de
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld de, -237
+; EZ80-NEXT:    ld de, -234
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, de
-; EZ80-NEXT:    ld iy, (hl)
-; EZ80-NEXT:    push iy
+; EZ80-NEXT:    ld hl, (hl)
+; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    pop hl
@@ -9399,13 +9384,12 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    push af
 ; EZ80-NEXT:    ex (sp), hl
 ; EZ80-NEXT:    ld (ix - 3), bc
-; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -255
+; EZ80-NEXT:    lea iy, ix
 ; EZ80-NEXT:    push af
-; EZ80-NEXT:    add ix, bc
+; EZ80-NEXT:    add iy, bc
 ; EZ80-NEXT:    pop af
-; EZ80-NEXT:    ld (ix), l
-; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld (iy), l
 ; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    ld hl, 9
 ; EZ80-NEXT:    add hl, sp
@@ -9438,13 +9422,11 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:  ; %bb.5:
 ; EZ80-NEXT:    ld l, a
 ; EZ80-NEXT:  BB37_6:
-; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld de, -243
-; EZ80-NEXT:    add ix, de
-; EZ80-NEXT:    ld bc, (ix)
-; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld a, c
-; EZ80-NEXT:    ld (ix - 3), bc
+; EZ80-NEXT:    ld bc, -246
+; EZ80-NEXT:    lea iy, ix
+; EZ80-NEXT:    add iy, bc
+; EZ80-NEXT:    ld iy, (iy)
+; EZ80-NEXT:    ld a, iyl
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -249
 ; EZ80-NEXT:    add ix, bc
@@ -9458,46 +9440,43 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), de
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld bc, (ix - 3)
-; EZ80-NEXT:    ld (ix - 78), bc
-; EZ80-NEXT:    ld.sis de, (ix - 77)
-; EZ80-NEXT:    ld (ix - 3), de
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld de, -240
+; EZ80-NEXT:    ld de, -243
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld bc, (ix)
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    ld a, c
-; EZ80-NEXT:    ld de, (ix - 3)
+; EZ80-NEXT:    ld (ix - 78), iy
+; EZ80-NEXT:    ld.sis de, (ix - 77)
 ; EZ80-NEXT:    ld (ix - 75), de
 ; EZ80-NEXT:    ld (ix - 73), a
-; EZ80-NEXT:    ld de, (ix - 75)
+; EZ80-NEXT:    ld iy, (ix - 75)
 ; EZ80-NEXT:    ld (ix - 3), bc
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld bc, -240
+; EZ80-NEXT:    add ix, bc
+; EZ80-NEXT:    ld de, (ix)
+; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld a, e
+; EZ80-NEXT:    ld bc, (ix - 3)
+; EZ80-NEXT:    ld (ix - 72), bc
+; EZ80-NEXT:    ld.sis de, (ix - 71)
+; EZ80-NEXT:    ld (ix - 69), de
+; EZ80-NEXT:    ld (ix - 67), a
+; EZ80-NEXT:    ld de, (ix - 69)
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -243
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), de
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld bc, (ix - 3)
-; EZ80-NEXT:    ld (ix - 72), bc
-; EZ80-NEXT:    ld.sis de, (ix - 71)
-; EZ80-NEXT:    ld (ix - 3), de
+; EZ80-NEXT:    bit 0, l
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld de, -234
+; EZ80-NEXT:    push af
 ; EZ80-NEXT:    add ix, de
+; EZ80-NEXT:    pop af
 ; EZ80-NEXT:    ld bc, (ix)
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld a, c
-; EZ80-NEXT:    ld de, (ix - 3)
-; EZ80-NEXT:    ld (ix - 69), de
-; EZ80-NEXT:    ld (ix - 67), a
-; EZ80-NEXT:    ld de, (ix - 69)
-; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -240
-; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld (ix), de
-; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    bit 0, l
 ; EZ80-NEXT:    jr z, BB37_14
 ; EZ80-NEXT:  ; %bb.7:
 ; EZ80-NEXT:    bit 0, l
@@ -9513,22 +9492,24 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    jr nz, BB37_12
 ; EZ80-NEXT:  BB37_11:
 ; EZ80-NEXT:    ld de, -1
+; EZ80-NEXT:    ld (ix - 3), bc
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -240
+; EZ80-NEXT:    ld bc, -243
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), de
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:  BB37_12:
 ; EZ80-NEXT:    bit 0, l
-; EZ80-NEXT:    ld bc, -237
+; EZ80-NEXT:    ld de, -234
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    push af
-; EZ80-NEXT:    add hl, bc
+; EZ80-NEXT:    add hl, de
 ; EZ80-NEXT:    pop af
-; EZ80-NEXT:    ld (hl), iy
+; EZ80-NEXT:    ld (hl), bc
 ; EZ80-NEXT:    jr nz, BB37_18
 ; EZ80-NEXT:  ; %bb.13:
-; EZ80-NEXT:    ld de, -246
+; EZ80-NEXT:    ld de, -231
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, de
 ; EZ80-NEXT:    ld bc, (hl)
@@ -9536,163 +9517,166 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:  BB37_14:
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    pop bc
 ; EZ80-NEXT:    bit 0, l
 ; EZ80-NEXT:    jr nz, BB37_8
 ; EZ80-NEXT:  BB37_15:
 ; EZ80-NEXT:    ld de, 0
+; EZ80-NEXT:    ld (ix - 3), bc
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -231
+; EZ80-NEXT:    ld bc, -237
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), de
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    bit 0, l
 ; EZ80-NEXT:    jr nz, BB37_9
 ; EZ80-NEXT:  BB37_16:
 ; EZ80-NEXT:    ld de, -32768
+; EZ80-NEXT:    ld (ix - 3), bc
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -228
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), de
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    bit 0, l
 ; EZ80-NEXT:    jr nz, BB37_10
 ; EZ80-NEXT:  BB37_17:
 ; EZ80-NEXT:    ld de, -1
-; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -243
-; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld (ix), de
-; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    bit 0, l
 ; EZ80-NEXT:    jr z, BB37_11
 ; EZ80-NEXT:    jr BB37_12
 ; EZ80-NEXT:  BB37_18:
-; EZ80-NEXT:    ld de, -234
+; EZ80-NEXT:    ld de, -240
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, de
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    ld b, h
 ; EZ80-NEXT:  BB37_19:
-; EZ80-NEXT:    ld de, -228
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    ld d, iyh
+; EZ80-NEXT:    ld (ix - 3), bc
+; EZ80-NEXT:    ld bc, -228
 ; EZ80-NEXT:    lea hl, ix
-; EZ80-NEXT:    add hl, de
+; EZ80-NEXT:    add hl, bc
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    ld (ix - 66), hl
-; EZ80-NEXT:    push af
-; EZ80-NEXT:    ld a, (ix - 64)
-; EZ80-NEXT:    ld iyl, a
-; EZ80-NEXT:    pop af
-; EZ80-NEXT:    ld (ix - 3), bc
+; EZ80-NEXT:    ld l, (ix - 64)
+; EZ80-NEXT:    ld (ix - 63), hl
+; EZ80-NEXT:    ld bc, -258
+; EZ80-NEXT:    lea hl, ix
+; EZ80-NEXT:    add hl, bc
+; EZ80-NEXT:    ld (hl), de
+; EZ80-NEXT:    ld.sis (ix - 62), de
+; EZ80-NEXT:    ld hl, (ix - 63)
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld bc, -231
+; EZ80-NEXT:    add ix, bc
+; EZ80-NEXT:    ld (ix), hl
+; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    ld bc, -243
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
-; EZ80-NEXT:    ld de, (hl)
-; EZ80-NEXT:    ld l, e
-; EZ80-NEXT:    ld h, d
-; EZ80-NEXT:    ld (ix - 63), iy
-; EZ80-NEXT:    ld bc, -255
-; EZ80-NEXT:    lea iy, ix
-; EZ80-NEXT:    add iy, bc
-; EZ80-NEXT:    ld (iy), hl
-; EZ80-NEXT:    ld.sis (ix - 62), hl
-; EZ80-NEXT:    ld hl, (ix - 63)
+; EZ80-NEXT:    ld hl, (hl)
+; EZ80-NEXT:    lea de, iy
+; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld iyl, e
+; EZ80-NEXT:    ld iyh, d
+; EZ80-NEXT:    ex de, hl
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -234
+; EZ80-NEXT:    ld bc, -249
 ; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld (ix), hl
+; EZ80-NEXT:    ld (ix), de
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    ld (ix - 60), de
-; EZ80-NEXT:    push af
-; EZ80-NEXT:    ld a, (ix - 58)
-; EZ80-NEXT:    ld iyl, a
-; EZ80-NEXT:    pop af
+; EZ80-NEXT:    ld e, (ix - 58)
+; EZ80-NEXT:    ld (ix - 57), de
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld bc, -261
+; EZ80-NEXT:    add ix, bc
+; EZ80-NEXT:    ld (ix), iy
+; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld.sis (ix - 56), iy
+; EZ80-NEXT:    ld de, (ix - 57)
 ; EZ80-NEXT:    ld bc, -240
-; EZ80-NEXT:    lea hl, ix
-; EZ80-NEXT:    add hl, bc
-; EZ80-NEXT:    ld hl, (hl)
-; EZ80-NEXT:    ld e, l
-; EZ80-NEXT:    ld d, h
-; EZ80-NEXT:    ld (ix - 57), iy
-; EZ80-NEXT:    ld bc, -258
 ; EZ80-NEXT:    lea iy, ix
 ; EZ80-NEXT:    add iy, bc
 ; EZ80-NEXT:    ld (iy), de
-; EZ80-NEXT:    ld.sis (ix - 56), de
-; EZ80-NEXT:    ld de, (ix - 57)
-; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -249
-; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld (ix), de
-; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    ld (ix - 54), hl
 ; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    ld c, (ix - 52)
+; EZ80-NEXT:    ld hl, 0
+; EZ80-NEXT:    push bc
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld c, l
+; EZ80-NEXT:    ld b, h
 ; EZ80-NEXT:    ld hl, 32767
 ; EZ80-NEXT:    ld (ix - 51), hl
 ; EZ80-NEXT:    ld e, (ix - 49)
-; EZ80-NEXT:    ld iy, 0
-; EZ80-NEXT:    ex de, hl
-; EZ80-NEXT:    ld e, iyl
-; EZ80-NEXT:    ld d, iyh
-; EZ80-NEXT:    ex de, hl
 ; EZ80-NEXT:    ld (ix - 48), de
-; EZ80-NEXT:    ld.sis (ix - 47), hl
-; EZ80-NEXT:    ld de, (ix - 48)
-; EZ80-NEXT:    ld (ix - 3), bc
+; EZ80-NEXT:    ld.sis (ix - 47), bc
+; EZ80-NEXT:    ld hl, (ix - 48)
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -261
-; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld (ix), de
+; EZ80-NEXT:    ld de, -252
+; EZ80-NEXT:    add ix, de
+; EZ80-NEXT:    ld (ix), hl
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld (ix - 45), iy
-; EZ80-NEXT:    ld e, (ix - 43)
-; EZ80-NEXT:    ld (ix - 42), de
+; EZ80-NEXT:    or a, a
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ld (ix - 45), hl
+; EZ80-NEXT:    ld l, (ix - 43)
+; EZ80-NEXT:    ld (ix - 42), hl
+; EZ80-NEXT:    ld de, -255
+; EZ80-NEXT:    lea hl, ix
+; EZ80-NEXT:    add hl, de
+; EZ80-NEXT:    ld (hl), bc
+; EZ80-NEXT:    ld.sis (ix - 41), bc
+; EZ80-NEXT:    ld de, (ix - 42)
+; EZ80-NEXT:    or a, a
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ld (ix - 39), hl
+; EZ80-NEXT:    ld l, (ix - 37)
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -252
+; EZ80-NEXT:    ld bc, -246
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), hl
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld.sis (ix - 41), hl
-; EZ80-NEXT:    ld de, (ix - 42)
-; EZ80-NEXT:    ld (ix - 39), iy
-; EZ80-NEXT:    ld h, 0
-; EZ80-NEXT:    ld l, (ix - 37)
-; EZ80-NEXT:    ld bc, -246
-; EZ80-NEXT:    lea iy, ix
-; EZ80-NEXT:    add iy, bc
-; EZ80-NEXT:    ld (iy), hl
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    push de
-; EZ80-NEXT:    ld bc, -261
+; EZ80-NEXT:    ld bc, -252
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld bc, -234
+; EZ80-NEXT:    ld bc, -231
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -249
+; EZ80-NEXT:    ld bc, -240
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld de, (ix)
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld bc, (ix - 3)
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    ; kill: def $bc killed $bc killed $ubc
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld bc, -231
+; EZ80-NEXT:    add ix, bc
+; EZ80-NEXT:    ld (ix), iy
+; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld c, iyl
+; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    call __llcmps
 ; EZ80-NEXT:    push af
 ; EZ80-NEXT:    ex (sp), hl
 ; EZ80-NEXT:    ld (ix - 3), bc
-; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -234
+; EZ80-NEXT:    ld bc, -240
+; EZ80-NEXT:    lea iy, ix
 ; EZ80-NEXT:    push af
-; EZ80-NEXT:    add ix, bc
+; EZ80-NEXT:    add iy, bc
 ; EZ80-NEXT:    pop af
-; EZ80-NEXT:    ld (ix), l
-; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld (iy), l
 ; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    ld hl, 9
 ; EZ80-NEXT:    add hl, sp
@@ -9718,11 +9702,10 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:  ; %bb.20:
 ; EZ80-NEXT:    ld l, a
 ; EZ80-NEXT:  BB37_21:
-; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -249
-; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld (ix), l
-; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld bc, -252
+; EZ80-NEXT:    lea iy, ix
+; EZ80-NEXT:    add iy, bc
+; EZ80-NEXT:    ld (iy), l
 ; EZ80-NEXT:    ld bc, -228
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
@@ -9730,7 +9713,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld (ix - 36), hl
 ; EZ80-NEXT:    ld l, (ix - 34)
 ; EZ80-NEXT:    ld (ix - 33), hl
-; EZ80-NEXT:    ld bc, -255
+; EZ80-NEXT:    ld bc, -258
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
 ; EZ80-NEXT:    ld hl, (hl)
@@ -9740,29 +9723,33 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), hl
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld bc, -243
+; EZ80-NEXT:    ld bc, -249
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    ld (ix - 30), hl
 ; EZ80-NEXT:    ld e, (ix - 28)
 ; EZ80-NEXT:    ld (ix - 27), de
-; EZ80-NEXT:    ld de, -258
+; EZ80-NEXT:    ld de, -261
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, de
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    ld.sis (ix - 26), hl
 ; EZ80-NEXT:    ld hl, (ix - 27)
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld de, -243
+; EZ80-NEXT:    ld de, -249
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld (ix), hl
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld de, -240
+; EZ80-NEXT:    ld de, -243
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, de
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    ld (ix - 24), hl
+; EZ80-NEXT:    ld de, -231
+; EZ80-NEXT:    lea hl, ix
+; EZ80-NEXT:    add hl, de
+; EZ80-NEXT:    ld iy, (hl)
 ; EZ80-NEXT:    push af
 ; EZ80-NEXT:    ld a, (ix - 22)
 ; EZ80-NEXT:    ld iyl, a
@@ -9771,14 +9758,14 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld (ix - 21), hl
 ; EZ80-NEXT:    ld c, (ix - 19)
 ; EZ80-NEXT:    ld (ix - 18), bc
-; EZ80-NEXT:    ld bc, -252
+; EZ80-NEXT:    ld bc, -255
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
 ; EZ80-NEXT:    ld de, (hl)
 ; EZ80-NEXT:    ld.sis (ix - 17), de
 ; EZ80-NEXT:    ld hl, (ix - 18)
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -240
+; EZ80-NEXT:    ld bc, -231
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), hl
 ; EZ80-NEXT:    pop ix
@@ -9796,17 +9783,17 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld l, (ix - 7)
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    push bc
-; EZ80-NEXT:    ld bc, -240
+; EZ80-NEXT:    ld bc, -231
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld bc, -255
+; EZ80-NEXT:    ld bc, -258
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -243
+; EZ80-NEXT:    ld bc, -249
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld de, (ix)
 ; EZ80-NEXT:    pop ix
@@ -9816,7 +9803,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    push af
 ; EZ80-NEXT:    ex (sp), hl
 ; EZ80-NEXT:    ld (ix - 3), bc
-; EZ80-NEXT:    ld bc, -240
+; EZ80-NEXT:    ld bc, -231
 ; EZ80-NEXT:    lea iy, ix
 ; EZ80-NEXT:    push af
 ; EZ80-NEXT:    add iy, bc
@@ -9836,7 +9823,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    jr z, BB37_23
 ; EZ80-NEXT:  ; %bb.22:
-; EZ80-NEXT:    ld bc, -234
+; EZ80-NEXT:    ld bc, -240
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, bc
 ; EZ80-NEXT:    ld (hl), a ; 1-byte Folded Spill
@@ -9853,12 +9840,12 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld de, -237
+; EZ80-NEXT:    ld de, -234
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, de
 ; EZ80-NEXT:    ld hl, (hl)
 ; EZ80-NEXT:    ld (ix - 3), bc
-; EZ80-NEXT:    ld bc, -231
+; EZ80-NEXT:    ld bc, -237
 ; EZ80-NEXT:    lea iy, ix
 ; EZ80-NEXT:    add iy, bc
 ; EZ80-NEXT:    ld de, (iy)
@@ -9868,7 +9855,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ex (sp), hl
 ; EZ80-NEXT:    ld (ix - 3), bc
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -240
+; EZ80-NEXT:    ld bc, -231
 ; EZ80-NEXT:    push af
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    pop af
@@ -9889,7 +9876,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    sbc a, a
 ; EZ80-NEXT:    ld e, a
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -249
+; EZ80-NEXT:    ld bc, -252
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld a, (ix)
 ; EZ80-NEXT:    pop ix
@@ -9897,7 +9884,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ; kill: def $a killed $a
 ; EZ80-NEXT:    sbc a, a
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -234
+; EZ80-NEXT:    ld bc, -240
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    bit 0, (ix) ; 1-byte Folded Reload
 ; EZ80-NEXT:    pop ix
@@ -9927,7 +9914,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld b, d
 ; EZ80-NEXT:    ld (ix - 3), bc
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld bc, -231
+; EZ80-NEXT:    ld bc, -237
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld de, (ix)
 ; EZ80-NEXT:    pop ix
@@ -9947,7 +9934,7 @@ define i64 @smul.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:  BB37_31:
 ; EZ80-NEXT:    ld bc, -1
 ; EZ80-NEXT:    ld (ix - 3), de
-; EZ80-NEXT:    ld de, -231
+; EZ80-NEXT:    ld de, -237
 ; EZ80-NEXT:    lea iy, ix
 ; EZ80-NEXT:    add iy, de
 ; EZ80-NEXT:    ld (iy), bc
@@ -9965,72 +9952,66 @@ define i8 @umul.fix.sat.i8.8(i8, i8) {
 ; Z80:       ; %bb.0:
 ; Z80-NEXT:    ld iy, 0
 ; Z80-NEXT:    add iy, sp
-; Z80-NEXT:    ld d, 0
-; Z80-NEXT:    ld e, (iy + 2)
-; Z80-NEXT:    ld b, d
+; Z80-NEXT:    ld b, 0
 ; Z80-NEXT:    ld c, (iy + 4)
-; Z80-NEXT:    ld l, e
-; Z80-NEXT:    ld h, d
+; Z80-NEXT:    ld h, b
+; Z80-NEXT:    ld l, (iy + 2)
 ; Z80-NEXT:    call __smulu
-; Z80-NEXT:    ld e, h
-; Z80-NEXT:    ld bc, 255
-; Z80-NEXT:    ld l, e
-; Z80-NEXT:    ld h, d
+; Z80-NEXT:    ld c, h
+; Z80-NEXT:    ld de, 255
+; Z80-NEXT:    ld l, c
+; Z80-NEXT:    ld h, b
 ; Z80-NEXT:    or a, a
-; Z80-NEXT:    sbc hl, bc
+; Z80-NEXT:    sbc hl, de
 ; Z80-NEXT:    jr c, BB38_2
 ; Z80-NEXT:  ; %bb.1:
-; Z80-NEXT:    ld de, 255
+; Z80-NEXT:    ld bc, 255
 ; Z80-NEXT:  BB38_2:
-; Z80-NEXT:    ld a, e
+; Z80-NEXT:    ld a, c
 ; Z80-NEXT:    ret
 ;
 ; EZ80-CODE16-LABEL: umul.fix.sat.i8.8:
 ; EZ80-CODE16:       ; %bb.0:
 ; EZ80-CODE16-NEXT:    ld iy, 0
 ; EZ80-CODE16-NEXT:    add iy, sp
-; EZ80-CODE16-NEXT:    ld d, 0
-; EZ80-CODE16-NEXT:    ld e, (iy + 2)
-; EZ80-CODE16-NEXT:    ld b, d
+; EZ80-CODE16-NEXT:    ld b, 0
 ; EZ80-CODE16-NEXT:    ld c, (iy + 4)
-; EZ80-CODE16-NEXT:    ld l, e
-; EZ80-CODE16-NEXT:    ld h, d
+; EZ80-CODE16-NEXT:    ld h, b
+; EZ80-CODE16-NEXT:    ld l, (iy + 2)
 ; EZ80-CODE16-NEXT:    call __smulu
-; EZ80-CODE16-NEXT:    ld e, h
-; EZ80-CODE16-NEXT:    ld bc, 255
-; EZ80-CODE16-NEXT:    ld l, e
-; EZ80-CODE16-NEXT:    ld h, d
+; EZ80-CODE16-NEXT:    ld c, h
+; EZ80-CODE16-NEXT:    ld de, 255
+; EZ80-CODE16-NEXT:    ld l, c
+; EZ80-CODE16-NEXT:    ld h, b
 ; EZ80-CODE16-NEXT:    or a, a
-; EZ80-CODE16-NEXT:    sbc hl, bc
+; EZ80-CODE16-NEXT:    sbc hl, de
 ; EZ80-CODE16-NEXT:    jr c, BB38_2
 ; EZ80-CODE16-NEXT:  ; %bb.1:
-; EZ80-CODE16-NEXT:    ld de, 255
+; EZ80-CODE16-NEXT:    ld bc, 255
 ; EZ80-CODE16-NEXT:  BB38_2:
-; EZ80-CODE16-NEXT:    ld a, e
+; EZ80-CODE16-NEXT:    ld a, c
 ; EZ80-CODE16-NEXT:    ret
 ;
 ; EZ80-LABEL: umul.fix.sat.i8.8:
 ; EZ80:       ; %bb.0:
 ; EZ80-NEXT:    ld iy, 0
 ; EZ80-NEXT:    add iy, sp
-; EZ80-NEXT:    ld d, 0
-; EZ80-NEXT:    ld e, (iy + 3)
-; EZ80-NEXT:    ld b, d
+; EZ80-NEXT:    ld b, 0
 ; EZ80-NEXT:    ld c, (iy + 6)
-; EZ80-NEXT:    ld l, e
-; EZ80-NEXT:    ld h, d
+; EZ80-NEXT:    ld h, b
+; EZ80-NEXT:    ld l, (iy + 3)
 ; EZ80-NEXT:    call __smulu
-; EZ80-NEXT:    ld e, h
-; EZ80-NEXT:    ld.sis bc, 255
-; EZ80-NEXT:    ld l, e
-; EZ80-NEXT:    ld h, d
+; EZ80-NEXT:    ld c, h
+; EZ80-NEXT:    ld.sis de, 255
+; EZ80-NEXT:    ld l, c
+; EZ80-NEXT:    ld h, b
 ; EZ80-NEXT:    or a, a
-; EZ80-NEXT:    sbc.sis hl, bc
+; EZ80-NEXT:    sbc.sis hl, de
 ; EZ80-NEXT:    jr c, BB38_2
 ; EZ80-NEXT:  ; %bb.1:
-; EZ80-NEXT:    ld.sis de, 255
+; EZ80-NEXT:    ld.sis bc, 255
 ; EZ80-NEXT:  BB38_2:
-; EZ80-NEXT:    ld a, e
+; EZ80-NEXT:    ld a, c
 ; EZ80-NEXT:    ret
   call i8 @llvm.umul.fix.sat.i8(i8 %0, i8 %1, i32 8)
   ret i8 %3
@@ -10091,17 +10072,21 @@ define i16 @umul.fix.sat.i16.8(i16, i16) {
 ;
 ; EZ80-LABEL: umul.fix.sat.i16.8:
 ; EZ80:       ; %bb.0:
-; EZ80-NEXT:    ld iy, 0
-; EZ80-NEXT:    add iy, sp
-; EZ80-NEXT:    ld de, (iy + 3)
-; EZ80-NEXT:    ld iy, (iy + 6)
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld l, e
-; EZ80-NEXT:    ld h, d
-; EZ80-NEXT:    ld d, 0
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld ix, 0
+; EZ80-NEXT:    add ix, sp
+; EZ80-NEXT:    ld iy, (ix + 6)
+; EZ80-NEXT:    ld hl, (ix + 9)
 ; EZ80-NEXT:    ld bc, 0
-; EZ80-NEXT:    ld c, iyl
-; EZ80-NEXT:    ld b, iyh
+; EZ80-NEXT:    ld c, l
+; EZ80-NEXT:    ld b, h
+; EZ80-NEXT:    ld d, 0
+; EZ80-NEXT:    or a, a
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    ld d, iyh
+; EZ80-NEXT:    ex de, hl
 ; EZ80-NEXT:    ld e, d
 ; EZ80-NEXT:    ld a, d
 ; EZ80-NEXT:    call __lmulu
@@ -10122,6 +10107,7 @@ define i16 @umul.fix.sat.i16.8(i16, i16) {
 ; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:  BB39_2:
 ; EZ80-NEXT:    ; kill: def $hl killed $hl killed $uhl
+; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    ret
   call i16 @llvm.umul.fix.sat.i16(i16 %0, i16 %1, i32 8)
   ret i16 %3
@@ -10181,17 +10167,21 @@ define i16 @umul.fix.sat.i16.16(i16, i16) {
 ;
 ; EZ80-LABEL: umul.fix.sat.i16.16:
 ; EZ80:       ; %bb.0:
-; EZ80-NEXT:    ld iy, 0
-; EZ80-NEXT:    add iy, sp
-; EZ80-NEXT:    ld de, (iy + 3)
-; EZ80-NEXT:    ld iy, (iy + 6)
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld l, e
-; EZ80-NEXT:    ld h, d
-; EZ80-NEXT:    ld d, 0
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld ix, 0
+; EZ80-NEXT:    add ix, sp
+; EZ80-NEXT:    ld iy, (ix + 6)
+; EZ80-NEXT:    ld hl, (ix + 9)
 ; EZ80-NEXT:    ld bc, 0
-; EZ80-NEXT:    ld c, iyl
-; EZ80-NEXT:    ld b, iyh
+; EZ80-NEXT:    ld c, l
+; EZ80-NEXT:    ld b, h
+; EZ80-NEXT:    ld d, 0
+; EZ80-NEXT:    or a, a
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    ld d, iyh
+; EZ80-NEXT:    ex de, hl
 ; EZ80-NEXT:    ld e, d
 ; EZ80-NEXT:    ld a, d
 ; EZ80-NEXT:    call __lmulu
@@ -10212,6 +10202,7 @@ define i16 @umul.fix.sat.i16.16(i16, i16) {
 ; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:  BB40_2:
 ; EZ80-NEXT:    ; kill: def $hl killed $hl killed $uhl
+; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    ret
   call i16 @llvm.umul.fix.sat.i16(i16 %0, i16 %1, i32 16)
   ret i16 %3
@@ -10394,22 +10385,18 @@ define i32 @umul.fix.sat.i32.16(i32, i32) {
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    dec sp
-; EZ80-NEXT:    ld hl, (ix + 12)
-; EZ80-NEXT:    ld a, (ix + 15)
+; EZ80-NEXT:    ld a, (ix + 9)
+; EZ80-NEXT:    ld iy, (ix + 12)
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop bc
-; EZ80-NEXT:    ld c, (ix + 9)
-; EZ80-NEXT:    ld.sis iy, 0
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    ld l, (ix + 15)
+; EZ80-NEXT:    ld.sis bc, 0
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    ld e, a
-; EZ80-NEXT:    push de
 ; EZ80-NEXT:    push hl
+; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    ld hl, (ix + 6)
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    pop de
-; EZ80-NEXT:    ld c, iyl
-; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    call __llmulu
 ; EZ80-NEXT:    ld iy, 9
 ; EZ80-NEXT:    add iy, sp
@@ -10635,22 +10622,18 @@ define i32 @umul.fix.sat.i32.32(i32, i32) {
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    dec sp
-; EZ80-NEXT:    ld hl, (ix + 12)
-; EZ80-NEXT:    ld a, (ix + 15)
+; EZ80-NEXT:    ld a, (ix + 9)
+; EZ80-NEXT:    ld iy, (ix + 12)
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop bc
-; EZ80-NEXT:    ld c, (ix + 9)
-; EZ80-NEXT:    ld.sis iy, 0
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    ld l, (ix + 15)
+; EZ80-NEXT:    ld.sis bc, 0
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    ld e, a
-; EZ80-NEXT:    push de
 ; EZ80-NEXT:    push hl
+; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    ld hl, (ix + 6)
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    pop de
-; EZ80-NEXT:    ld c, iyl
-; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    call __llmulu
 ; EZ80-NEXT:    ld iy, 9
 ; EZ80-NEXT:    add iy, sp
@@ -10729,13 +10712,6 @@ define i64 @umul.fix.sat.i64.32(i64, i64) {
 ; Z80-NEXT:    ld h, (ix + 9)
 ; Z80-NEXT:    ld e, (ix + 10)
 ; Z80-NEXT:    ld d, (ix + 11)
-; Z80-NEXT:    ld c, (ix + 12)
-; Z80-NEXT:    ld b, (ix + 13)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix + 14)
-; Z80-NEXT:    ld h, (ix + 15)
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    pop iy
 ; Z80-NEXT:    call __lmulu
 ; Z80-NEXT:    ld (ix - 4), l
 ; Z80-NEXT:    ld (ix - 3), h
@@ -11553,8 +11529,6 @@ define i64 @umul.fix.sat.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld (ix - 8), de
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 8)
 ; EZ80-CODE16-NEXT:    ld de, (ix + 10)
-; EZ80-CODE16-NEXT:    ld bc, (ix + 12)
-; EZ80-CODE16-NEXT:    ld iy, (ix + 14)
 ; EZ80-CODE16-NEXT:    call __lmulu
 ; EZ80-CODE16-NEXT:    ld (ix - 4), hl
 ; EZ80-CODE16-NEXT:    ld (ix - 2), de
@@ -12114,23 +12088,27 @@ define i64 @umul.fix.sat.i64.32(i64, i64) {
 ; EZ80-NEXT:    ld hl, -203
 ; EZ80-NEXT:    add hl, sp
 ; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    ld bc, (ix + 9)
 ; EZ80-NEXT:    ld de, (ix + 12)
-; EZ80-NEXT:    ld iy, 0
-; EZ80-NEXT:    ld iyl, e
-; EZ80-NEXT:    ld iyh, d
+; EZ80-NEXT:    ld iy, (ix + 21)
+; EZ80-NEXT:    or a, a
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld e, iyl
+; EZ80-NEXT:    ld d, iyh
+; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld (ix - 3), bc
+; EZ80-NEXT:    ld bc, -144
+; EZ80-NEXT:    lea iy, ix
+; EZ80-NEXT:    add iy, bc
+; EZ80-NEXT:    ld (iy), hl
 ; EZ80-NEXT:    or a, a
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    pop bc
-; EZ80-NEXT:    ld de, (ix + 21)
-; EZ80-NEXT:    ld c, e
-; EZ80-NEXT:    ld b, d
-; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld de, -144
-; EZ80-NEXT:    add ix, de
-; EZ80-NEXT:    ld (ix), bc
-; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld bc, (ix + 9)
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld iyl, e
+; EZ80-NEXT:    ld iyh, d
+; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    ld l, c
 ; EZ80-NEXT:    ex de, hl
 ; EZ80-NEXT:    ld (ix - 3), bc
@@ -12189,15 +12167,15 @@ define i64 @umul.fix.sat.i64.32(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), de
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld hl, (ix + 9)
-; EZ80-NEXT:    ld (ix - 123), hl
-; EZ80-NEXT:    ld.sis hl, (ix - 122)
 ; EZ80-NEXT:    ld a, iyl
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -150
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), a
 ; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld hl, (ix + 9)
+; EZ80-NEXT:    ld (ix - 123), hl
+; EZ80-NEXT:    ld.sis hl, (ix - 122)
 ; EZ80-NEXT:    ld (ix - 120), hl
 ; EZ80-NEXT:    ld (ix - 118), a
 ; EZ80-NEXT:    ld hl, (ix - 120)
@@ -12212,9 +12190,8 @@ define i64 @umul.fix.sat.i64.32(i64, i64) {
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -138
 ; EZ80-NEXT:    add ix, bc
-; EZ80-NEXT:    ld d, (ix) ; 1-byte Folded Reload
+; EZ80-NEXT:    ld a, (ix) ; 1-byte Folded Reload
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld a, d
 ; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    call __lmulu
 ; EZ80-NEXT:    ld (ix - 3), bc
@@ -12228,26 +12205,26 @@ define i64 @umul.fix.sat.i64.32(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), e ; 1-byte Folded Spill
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld hl, (ix + 18)
-; EZ80-NEXT:    ld (ix - 117), hl
-; EZ80-NEXT:    ld bc, (ix - 3)
-; EZ80-NEXT:    ld.sis bc, (ix - 116)
-; EZ80-NEXT:    ld (ix - 3), de
-; EZ80-NEXT:    ld de, -144
-; EZ80-NEXT:    lea hl, ix
-; EZ80-NEXT:    add hl, de
-; EZ80-NEXT:    ld hl, (hl)
-; EZ80-NEXT:    ld a, l
 ; EZ80-NEXT:    push ix
-; EZ80-NEXT:    ld de, -156
-; EZ80-NEXT:    add ix, de
+; EZ80-NEXT:    ld bc, -144
+; EZ80-NEXT:    add ix, bc
+; EZ80-NEXT:    ld de, (ix)
+; EZ80-NEXT:    pop ix
+; EZ80-NEXT:    ld a, e
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld bc, -156
+; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), a
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld (ix - 114), bc
+; EZ80-NEXT:    ld hl, (ix + 18)
+; EZ80-NEXT:    ld (ix - 117), hl
+; EZ80-NEXT:    ld.sis hl, (ix - 116)
+; EZ80-NEXT:    ld (ix - 114), hl
 ; EZ80-NEXT:    ld (ix - 112), a
+; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    ld bc, (ix - 114)
-; EZ80-NEXT:    ld a, h
-; EZ80-NEXT:    dec de
+; EZ80-NEXT:    ld a, d
+; EZ80-NEXT:    ld de, -157
 ; EZ80-NEXT:    lea hl, ix
 ; EZ80-NEXT:    add hl, de
 ; EZ80-NEXT:    ld (hl), a
@@ -12257,7 +12234,6 @@ define i64 @umul.fix.sat.i64.32(i64, i64) {
 ; EZ80-NEXT:    add ix, de
 ; EZ80-NEXT:    ld iy, (ix)
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld de, (ix - 3)
 ; EZ80-NEXT:    ld e, iyl
 ; EZ80-NEXT:    call __lmulu
 ; EZ80-NEXT:    ld (ix - 3), bc
@@ -12273,7 +12249,11 @@ define i64 @umul.fix.sat.i64.32(i64, i64) {
 ; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    or a, a
 ; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld l, d
+; EZ80-NEXT:    push ix
+; EZ80-NEXT:    ld bc, -138
+; EZ80-NEXT:    add ix, bc
+; EZ80-NEXT:    ld l, (ix) ; 1-byte Folded Reload
+; EZ80-NEXT:    pop ix
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld bc, -153
 ; EZ80-NEXT:    add ix, bc
@@ -12384,11 +12364,11 @@ define i64 @umul.fix.sat.i64.32(i64, i64) {
 ; EZ80-NEXT:    add ix, bc
 ; EZ80-NEXT:    ld (ix), e ; 1-byte Folded Spill
 ; EZ80-NEXT:    pop ix
-; EZ80-NEXT:    ld l, 0
 ; EZ80-NEXT:    ld bc, (ix - 3)
 ; EZ80-NEXT:    ld bc, 0
 ; EZ80-NEXT:    ld iyl, c
 ; EZ80-NEXT:    ld iyh, b
+; EZ80-NEXT:    ld l, b
 ; EZ80-NEXT:    ld (ix - 111), hl
 ; EZ80-NEXT:    ld.sis (ix - 110), iy
 ; EZ80-NEXT:    ld (ix - 3), de
@@ -13892,6 +13872,7 @@ define i16 @sdiv.fix.sat.i16.7(i16, i16) {
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld iy, (ix + 6)
+; EZ80-NEXT:    ld d, 0
 ; EZ80-NEXT:    ld a, iyh
 ; EZ80-NEXT:    ld e, 7
 ; EZ80-NEXT:    ld l, a
@@ -13907,7 +13888,6 @@ define i16 @sdiv.fix.sat.i16.7(i16, i16) {
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    add iy, iy
 ; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld d, 0
 ; EZ80-NEXT:    ld a, l
 ; EZ80-NEXT:    ld l, e
 ; EZ80-NEXT:    call __lshl
@@ -14166,7 +14146,6 @@ define i16 @sdiv.fix.sat.i16.15(i16, i16) {
 ; EZ80-NEXT:    pop iy
 ; EZ80-NEXT:    add iy, iy
 ; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld d, 0
 ; EZ80-NEXT:    ld e, 15
 ; EZ80-NEXT:    ld a, l
 ; EZ80-NEXT:    ld l, e
@@ -14223,7 +14202,7 @@ define i16 @sdiv.fix.sat.i16.15(i16, i16) {
 ; EZ80-NEXT:    ld bc, 32767
 ; EZ80-NEXT:    lea hl, iy
 ; EZ80-NEXT:    ld e, a
-; EZ80-NEXT:    ld a, d
+; EZ80-NEXT:    xor a, a
 ; EZ80-NEXT:    call __lcmps
 ; EZ80-NEXT:    call pe, __setflag
 ; EZ80-NEXT:    jp m, BB46_8
@@ -14401,7 +14380,6 @@ define i32 @sdiv.fix.sat.i32.15(i32, i32) {
 ; Z80-NEXT:    bit 0, a
 ; Z80-NEXT:    jp nz, BB47_5
 ; Z80-NEXT:  BB47_11:
-; Z80-NEXT:    ld de, -32768
 ; Z80-NEXT:    ld (ix - 2), e
 ; Z80-NEXT:    ld (ix - 1), d
 ; Z80-NEXT:    bit 0, a
@@ -14565,7 +14543,6 @@ define i32 @sdiv.fix.sat.i32.15(i32, i32) {
 ; EZ80-CODE16-NEXT:    bit 0, a
 ; EZ80-CODE16-NEXT:    jp nz, BB47_5
 ; EZ80-CODE16-NEXT:  BB47_11:
-; EZ80-CODE16-NEXT:    ld de, -32768
 ; EZ80-CODE16-NEXT:    ld (ix - 2), de
 ; EZ80-CODE16-NEXT:    bit 0, a
 ; EZ80-CODE16-NEXT:    jp nz, BB47_6
@@ -14918,7 +14895,6 @@ define i32 @sdiv.fix.sat.i32.31(i32, i32) {
 ; Z80-NEXT:    bit 0, a
 ; Z80-NEXT:    jp nz, BB48_5
 ; Z80-NEXT:  BB48_11:
-; Z80-NEXT:    ld de, -32768
 ; Z80-NEXT:    ld (ix - 2), e
 ; Z80-NEXT:    ld (ix - 1), d
 ; Z80-NEXT:    bit 0, a
@@ -15082,7 +15058,6 @@ define i32 @sdiv.fix.sat.i32.31(i32, i32) {
 ; EZ80-CODE16-NEXT:    bit 0, a
 ; EZ80-CODE16-NEXT:    jp nz, BB48_5
 ; EZ80-CODE16-NEXT:  BB48_11:
-; EZ80-CODE16-NEXT:    ld de, -32768
 ; EZ80-CODE16-NEXT:    ld (ix - 2), de
 ; EZ80-CODE16-NEXT:    bit 0, a
 ; EZ80-CODE16-NEXT:    jp nz, BB48_6
@@ -15283,7 +15258,7 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; Z80-NEXT:    push ix
 ; Z80-NEXT:    ld ix, 0
 ; Z80-NEXT:    add ix, sp
-; Z80-NEXT:    ld hl, -23
+; Z80-NEXT:    ld hl, -30
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
 ; Z80-NEXT:    push hl
@@ -15311,16 +15286,16 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; Z80-NEXT:    ld c, (ix + 8)
 ; Z80-NEXT:    ld b, (ix + 9)
 ; Z80-NEXT:    call __lldivs
-; Z80-NEXT:    ld (ix - 14), l
-; Z80-NEXT:    ld (ix - 13), h
-; Z80-NEXT:    ld (ix - 16), e
-; Z80-NEXT:    ld (ix - 15), d
-; Z80-NEXT:    ld (ix - 18), c
-; Z80-NEXT:    ld (ix - 17), b
+; Z80-NEXT:    ld (ix - 18), l
+; Z80-NEXT:    ld (ix - 17), h
+; Z80-NEXT:    ld (ix - 20), e
+; Z80-NEXT:    ld (ix - 19), d
+; Z80-NEXT:    ld (ix - 22), c
+; Z80-NEXT:    ld (ix - 21), b
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 20), l
-; Z80-NEXT:    ld (ix - 19), h
+; Z80-NEXT:    ld (ix - 24), l
+; Z80-NEXT:    ld (ix - 23), h
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
@@ -15391,57 +15366,29 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; Z80-NEXT:    ld c, (ix - 6)
 ; Z80-NEXT:    ld b, (ix - 5)
 ; Z80-NEXT:    call __llxor
-; Z80-NEXT:    ld (ix - 8), l
-; Z80-NEXT:    ld (ix - 7), h
-; Z80-NEXT:    ld (ix - 12), e
-; Z80-NEXT:    ld (ix - 11), d
+; Z80-NEXT:    ld (ix - 12), l
+; Z80-NEXT:    ld (ix - 11), h
+; Z80-NEXT:    ld (ix - 14), e
+; Z80-NEXT:    ld (ix - 13), d
+; Z80-NEXT:    ld (ix - 16), c
+; Z80-NEXT:    ld (ix - 15), b
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 22), l
-; Z80-NEXT:    ld (ix - 21), h
+; Z80-NEXT:    ld (ix - 26), l
+; Z80-NEXT:    ld (ix - 25), h
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    ld de, 0
-; Z80-NEXT:    push de
-; Z80-NEXT:    push de
-; Z80-NEXT:    ld hl, 16384
-; Z80-NEXT:    push hl
-; Z80-NEXT:    push de
 ; Z80-NEXT:    push iy
-; Z80-NEXT:    ld l, (ix - 8)
-; Z80-NEXT:    ld h, (ix - 7)
-; Z80-NEXT:    ld e, (ix - 12)
-; Z80-NEXT:    ld d, (ix - 11)
-; Z80-NEXT:    call __llcmpu
-; Z80-NEXT:    push af
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 23), l
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    ld hl, 10
-; Z80-NEXT:    add hl, sp
-; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 23)
-; Z80-NEXT:    ; kill: def $h killed $a
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    pop af
-; Z80-NEXT:    ccf
-; Z80-NEXT:    ; kill: def $a killed $a
-; Z80-NEXT:    sbc a, a
-; Z80-NEXT:    ld iyl, a
-; Z80-NEXT:    inc iyl
-; Z80-NEXT:    ld l, (ix - 22)
-; Z80-NEXT:    ld h, (ix - 21)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 8)
-; Z80-NEXT:    ld h, (ix - 7)
-; Z80-NEXT:    ld e, (ix - 12)
-; Z80-NEXT:    ld d, (ix - 11)
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
+; Z80-NEXT:    ld e, (ix - 14)
+; Z80-NEXT:    ld d, (ix - 13)
+; Z80-NEXT:    ld c, (ix - 16)
+; Z80-NEXT:    ld b, (ix - 15)
 ; Z80-NEXT:    call __llctlz
 ; Z80-NEXT:    ld l, a
-; Z80-NEXT:    ld a, iyl
 ; Z80-NEXT:    pop de
 ; Z80-NEXT:    ld h, 0
 ; Z80-NEXT:    ld de, -1
@@ -15456,9 +15403,45 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; Z80-NEXT:    call __lladd
 ; Z80-NEXT:    ld (ix - 8), l
 ; Z80-NEXT:    ld (ix - 7), h
+; Z80-NEXT:    ld (ix - 30), e
+; Z80-NEXT:    ld (ix - 29), d
+; Z80-NEXT:    ld (ix - 28), c
+; Z80-NEXT:    ld (ix - 27), b
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
+; Z80-NEXT:    ld hl, 16384
+; Z80-NEXT:    ld de, 0
+; Z80-NEXT:    push de
+; Z80-NEXT:    push de
+; Z80-NEXT:    push hl
+; Z80-NEXT:    push de
+; Z80-NEXT:    ld l, (ix - 26)
+; Z80-NEXT:    ld h, (ix - 25)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
+; Z80-NEXT:    ld e, (ix - 14)
+; Z80-NEXT:    ld d, (ix - 13)
+; Z80-NEXT:    ld c, (ix - 16)
+; Z80-NEXT:    ld b, (ix - 15)
+; Z80-NEXT:    call __llcmpu
+; Z80-NEXT:    push af
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    ld (ix - 12), l
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld hl, 10
+; Z80-NEXT:    add hl, sp
+; Z80-NEXT:    ld sp, hl
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ; kill: def $h killed $a
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    pop af
+; Z80-NEXT:    ccf
+; Z80-NEXT:    ; kill: def $a killed $a
+; Z80-NEXT:    sbc a, a
+; Z80-NEXT:    inc a
 ; Z80-NEXT:    bit 0, a
 ; Z80-NEXT:    jr z, BB49_2
 ; Z80-NEXT:  ; %bb.1:
@@ -15467,20 +15450,23 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; Z80-NEXT:    ld (ix - 7), h
 ; Z80-NEXT:  BB49_2:
 ; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld hl, 0
+; Z80-NEXT:    ld bc, 0
+; Z80-NEXT:    ld l, c
+; Z80-NEXT:    ld h, b
 ; Z80-NEXT:    jr nz, BB49_4
 ; Z80-NEXT:  ; %bb.3:
-; Z80-NEXT:    ex de, hl
+; Z80-NEXT:    ld l, (ix - 30)
+; Z80-NEXT:    ld h, (ix - 29)
 ; Z80-NEXT:  BB49_4:
 ; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld de, 0
-; Z80-NEXT:    jr nz, BB49_6
-; Z80-NEXT:  ; %bb.5:
 ; Z80-NEXT:    ld e, c
 ; Z80-NEXT:    ld d, b
+; Z80-NEXT:    jr nz, BB49_6
+; Z80-NEXT:  ; %bb.5:
+; Z80-NEXT:    ld e, (ix - 28)
+; Z80-NEXT:    ld d, (ix - 27)
 ; Z80-NEXT:  BB49_6:
 ; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld bc, 0
 ; Z80-NEXT:    jr nz, BB49_8
 ; Z80-NEXT:  ; %bb.7:
 ; Z80-NEXT:    ld c, iyl
@@ -15494,46 +15480,20 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; Z80-NEXT:    ld h, (ix - 7)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld hl, 0
-; Z80-NEXT:    ld c, l
-; Z80-NEXT:    ld b, h
-; Z80-NEXT:    push bc
+; Z80-NEXT:    ex de, hl
+; Z80-NEXT:    push de
 ; Z80-NEXT:    ex de, hl
 ; Z80-NEXT:    ld e, iyl
 ; Z80-NEXT:    ld d, iyh
 ; Z80-NEXT:    ex de, hl
-; Z80-NEXT:    ld e, c
-; Z80-NEXT:    ld d, b
+; Z80-NEXT:    ld c, e
+; Z80-NEXT:    ld b, d
 ; Z80-NEXT:    call __llsub
 ; Z80-NEXT:    ld (ix - 12), l
 ; Z80-NEXT:    ld (ix - 11), h
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    ld hl, 31
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 20)
-; Z80-NEXT:    ld h, (ix - 19)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 14)
-; Z80-NEXT:    ld h, (ix - 13)
-; Z80-NEXT:    ld e, (ix - 16)
-; Z80-NEXT:    ld d, (ix - 15)
-; Z80-NEXT:    ld c, (ix - 18)
-; Z80-NEXT:    ld b, (ix - 17)
-; Z80-NEXT:    call __llshl
-; Z80-NEXT:    ld (ix - 14), l
-; Z80-NEXT:    ld (ix - 13), h
-; Z80-NEXT:    ld (ix - 16), e
-; Z80-NEXT:    ld (ix - 15), d
-; Z80-NEXT:    ld (ix - 18), c
-; Z80-NEXT:    ld (ix - 17), b
-; Z80-NEXT:    push iy
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 20), l
-; Z80-NEXT:    ld (ix - 19), h
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    pop hl
 ; Z80-NEXT:    ld l, (ix - 8)
 ; Z80-NEXT:    ld h, (ix - 7)
 ; Z80-NEXT:    push hl
@@ -15634,23 +15594,48 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; Z80-NEXT:    call __llshrs
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld (ix - 4), e
+; Z80-NEXT:    ld (ix - 3), d
+; Z80-NEXT:    ld (ix - 6), c
+; Z80-NEXT:    ld (ix - 5), b
 ; Z80-NEXT:    push iy
-; Z80-NEXT:    push bc
-; Z80-NEXT:    push de
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    ld (ix - 8), l
+; Z80-NEXT:    ld (ix - 7), h
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld hl, 31
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 24)
+; Z80-NEXT:    ld h, (ix - 23)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 18)
+; Z80-NEXT:    ld h, (ix - 17)
+; Z80-NEXT:    ld e, (ix - 20)
+; Z80-NEXT:    ld d, (ix - 19)
+; Z80-NEXT:    ld c, (ix - 22)
+; Z80-NEXT:    ld b, (ix - 21)
+; Z80-NEXT:    call __llshl
+; Z80-NEXT:    ld (ix - 10), l
+; Z80-NEXT:    ld (ix - 9), h
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld l, (ix - 8)
+; Z80-NEXT:    ld h, (ix - 7)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 6)
+; Z80-NEXT:    ld h, (ix - 5)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 4)
+; Z80-NEXT:    ld h, (ix - 3)
+; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld l, (ix - 2)
 ; Z80-NEXT:    ld h, (ix - 1)
 ; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 20)
-; Z80-NEXT:    ld h, (ix - 19)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 14)
-; Z80-NEXT:    ld h, (ix - 13)
-; Z80-NEXT:    ld e, (ix - 16)
-; Z80-NEXT:    ld d, (ix - 15)
-; Z80-NEXT:    ld c, (ix - 18)
-; Z80-NEXT:    ld b, (ix - 17)
+; Z80-NEXT:    push iy
+; Z80-NEXT:    ld l, (ix - 10)
+; Z80-NEXT:    ld h, (ix - 9)
 ; Z80-NEXT:    call __lladd
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
@@ -15668,7 +15653,7 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    push ix
 ; EZ80-CODE16-NEXT:    ld ix, 0
 ; EZ80-CODE16-NEXT:    add ix, sp
-; EZ80-CODE16-NEXT:    lea hl, ix - 23
+; EZ80-CODE16-NEXT:    lea hl, ix - 30
 ; EZ80-CODE16-NEXT:    ld sp, hl
 ; EZ80-CODE16-NEXT:    ld iy, (ix + 12)
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 14)
@@ -15684,10 +15669,10 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld de, (ix + 6)
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 8)
 ; EZ80-CODE16-NEXT:    call __lldivs
-; EZ80-CODE16-NEXT:    ld (ix - 14), hl
-; EZ80-CODE16-NEXT:    ld (ix - 16), de
-; EZ80-CODE16-NEXT:    ld (ix - 18), bc
-; EZ80-CODE16-NEXT:    ld (ix - 20), iy
+; EZ80-CODE16-NEXT:    ld (ix - 18), hl
+; EZ80-CODE16-NEXT:    ld (ix - 20), de
+; EZ80-CODE16-NEXT:    ld (ix - 22), bc
+; EZ80-CODE16-NEXT:    ld (ix - 24), iy
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
@@ -15734,46 +15719,19 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld de, (ix - 4)
 ; EZ80-CODE16-NEXT:    ld bc, (ix - 6)
 ; EZ80-CODE16-NEXT:    call __llxor
-; EZ80-CODE16-NEXT:    ld (ix - 8), hl
-; EZ80-CODE16-NEXT:    ld (ix - 12), de
-; EZ80-CODE16-NEXT:    ld (ix - 22), iy
+; EZ80-CODE16-NEXT:    ld (ix - 12), hl
+; EZ80-CODE16-NEXT:    ld (ix - 14), de
+; EZ80-CODE16-NEXT:    ld (ix - 16), bc
+; EZ80-CODE16-NEXT:    ld (ix - 26), iy
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld de, 0
-; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    ld hl, 16384
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    push de
 ; EZ80-CODE16-NEXT:    push iy
-; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
-; EZ80-CODE16-NEXT:    ld de, (ix - 12)
-; EZ80-CODE16-NEXT:    call __llcmpu
-; EZ80-CODE16-NEXT:    push af
-; EZ80-CODE16-NEXT:    ex (sp), hl
-; EZ80-CODE16-NEXT:    ld (ix - 23), l
-; EZ80-CODE16-NEXT:    pop hl
-; EZ80-CODE16-NEXT:    ld hl, 10
-; EZ80-CODE16-NEXT:    add hl, sp
-; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld l, (ix - 23)
-; EZ80-CODE16-NEXT:    ; kill: def $h killed $a
-; EZ80-CODE16-NEXT:    ex (sp), hl
-; EZ80-CODE16-NEXT:    pop af
-; EZ80-CODE16-NEXT:    ccf
-; EZ80-CODE16-NEXT:    ; kill: def $a killed $a
-; EZ80-CODE16-NEXT:    sbc a, a
-; EZ80-CODE16-NEXT:    ld iyl, a
-; EZ80-CODE16-NEXT:    inc iyl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 22)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
-; EZ80-CODE16-NEXT:    ld de, (ix - 12)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
+; EZ80-CODE16-NEXT:    ld de, (ix - 14)
+; EZ80-CODE16-NEXT:    ld bc, (ix - 16)
 ; EZ80-CODE16-NEXT:    call __llctlz
 ; EZ80-CODE16-NEXT:    ld l, a
-; EZ80-CODE16-NEXT:    ld a, iyl
 ; EZ80-CODE16-NEXT:    pop de
 ; EZ80-CODE16-NEXT:    ld h, 0
 ; EZ80-CODE16-NEXT:    ld de, -1
@@ -15787,9 +15745,39 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld d, b
 ; EZ80-CODE16-NEXT:    call __lladd
 ; EZ80-CODE16-NEXT:    ld (ix - 8), hl
+; EZ80-CODE16-NEXT:    ld (ix - 30), de
+; EZ80-CODE16-NEXT:    ld (ix - 28), bc
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
+; EZ80-CODE16-NEXT:    ld hl, 16384
+; EZ80-CODE16-NEXT:    ld de, 0
+; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    ld hl, (ix - 26)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
+; EZ80-CODE16-NEXT:    ld de, (ix - 14)
+; EZ80-CODE16-NEXT:    ld bc, (ix - 16)
+; EZ80-CODE16-NEXT:    call __llcmpu
+; EZ80-CODE16-NEXT:    push af
+; EZ80-CODE16-NEXT:    ex (sp), hl
+; EZ80-CODE16-NEXT:    ld (ix - 12), l
+; EZ80-CODE16-NEXT:    pop hl
+; EZ80-CODE16-NEXT:    ld hl, 10
+; EZ80-CODE16-NEXT:    add hl, sp
+; EZ80-CODE16-NEXT:    ld sp, hl
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld l, (ix - 12)
+; EZ80-CODE16-NEXT:    ; kill: def $h killed $a
+; EZ80-CODE16-NEXT:    ex (sp), hl
+; EZ80-CODE16-NEXT:    pop af
+; EZ80-CODE16-NEXT:    ccf
+; EZ80-CODE16-NEXT:    ; kill: def $a killed $a
+; EZ80-CODE16-NEXT:    sbc a, a
+; EZ80-CODE16-NEXT:    inc a
 ; EZ80-CODE16-NEXT:    bit 0, a
 ; EZ80-CODE16-NEXT:    jr z, BB49_2
 ; EZ80-CODE16-NEXT:  ; %bb.1:
@@ -15797,20 +15785,21 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld (ix - 8), hl
 ; EZ80-CODE16-NEXT:  BB49_2:
 ; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    ld hl, 0
+; EZ80-CODE16-NEXT:    ld bc, 0
+; EZ80-CODE16-NEXT:    ld l, c
+; EZ80-CODE16-NEXT:    ld h, b
 ; EZ80-CODE16-NEXT:    jr nz, BB49_4
 ; EZ80-CODE16-NEXT:  ; %bb.3:
-; EZ80-CODE16-NEXT:    ex de, hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 30)
 ; EZ80-CODE16-NEXT:  BB49_4:
 ; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    ld de, 0
-; EZ80-CODE16-NEXT:    jr nz, BB49_6
-; EZ80-CODE16-NEXT:  ; %bb.5:
 ; EZ80-CODE16-NEXT:    ld e, c
 ; EZ80-CODE16-NEXT:    ld d, b
+; EZ80-CODE16-NEXT:    jr nz, BB49_6
+; EZ80-CODE16-NEXT:  ; %bb.5:
+; EZ80-CODE16-NEXT:    ld de, (ix - 28)
 ; EZ80-CODE16-NEXT:  BB49_6:
 ; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    ld bc, 0
 ; EZ80-CODE16-NEXT:    jr nz, BB49_8
 ; EZ80-CODE16-NEXT:  ; %bb.7:
 ; EZ80-CODE16-NEXT:    lea bc, iy
@@ -15822,30 +15811,14 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld hl, 0
-; EZ80-CODE16-NEXT:    ld c, l
-; EZ80-CODE16-NEXT:    ld b, h
-; EZ80-CODE16-NEXT:    push bc
+; EZ80-CODE16-NEXT:    ex de, hl
+; EZ80-CODE16-NEXT:    push de
 ; EZ80-CODE16-NEXT:    lea hl, iy
-; EZ80-CODE16-NEXT:    ld e, c
-; EZ80-CODE16-NEXT:    ld d, b
+; EZ80-CODE16-NEXT:    ld c, e
+; EZ80-CODE16-NEXT:    ld b, d
 ; EZ80-CODE16-NEXT:    call __llsub
 ; EZ80-CODE16-NEXT:    ld (ix - 12), hl
 ; EZ80-CODE16-NEXT:    ld hl, 10
-; EZ80-CODE16-NEXT:    add hl, sp
-; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld hl, 31
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 20)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 14)
-; EZ80-CODE16-NEXT:    ld de, (ix - 16)
-; EZ80-CODE16-NEXT:    ld bc, (ix - 18)
-; EZ80-CODE16-NEXT:    call __llshl
-; EZ80-CODE16-NEXT:    ld (ix - 14), hl
-; EZ80-CODE16-NEXT:    ld (ix - 16), de
-; EZ80-CODE16-NEXT:    ld (ix - 18), bc
-; EZ80-CODE16-NEXT:    ld (ix - 20), iy
-; EZ80-CODE16-NEXT:    ld hl, 4
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
@@ -15920,19 +15893,34 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    call __llshrs
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
+; EZ80-CODE16-NEXT:    ld (ix - 4), de
+; EZ80-CODE16-NEXT:    ld (ix - 6), bc
+; EZ80-CODE16-NEXT:    ld (ix - 8), iy
 ; EZ80-CODE16-NEXT:    ld hl, 4
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    push iy
-; EZ80-CODE16-NEXT:    push bc
-; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    ld hl, 31
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 24)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 18)
+; EZ80-CODE16-NEXT:    ld de, (ix - 20)
+; EZ80-CODE16-NEXT:    ld bc, (ix - 22)
+; EZ80-CODE16-NEXT:    call __llshl
+; EZ80-CODE16-NEXT:    ld (ix - 10), hl
+; EZ80-CODE16-NEXT:    ld hl, 4
+; EZ80-CODE16-NEXT:    add hl, sp
+; EZ80-CODE16-NEXT:    ld sp, hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 6)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 4)
+; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 20)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 14)
-; EZ80-CODE16-NEXT:    ld de, (ix - 16)
-; EZ80-CODE16-NEXT:    ld bc, (ix - 18)
+; EZ80-CODE16-NEXT:    push iy
+; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
 ; EZ80-CODE16-NEXT:    call __lladd
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
 ; EZ80-CODE16-NEXT:    ld hl, 10
@@ -15948,7 +15936,7 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
-; EZ80-NEXT:    lea hl, ix - 24
+; EZ80-NEXT:    lea hl, ix - 33
 ; EZ80-NEXT:    ld sp, hl
 ; EZ80-NEXT:    ld bc, (ix + 12)
 ; EZ80-NEXT:    ld de, (ix + 15)
@@ -15997,49 +15985,58 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld de, (ix - 3)
 ; EZ80-NEXT:    ld bc, (ix - 6)
 ; EZ80-NEXT:    call __llxor
-; EZ80-NEXT:    ld iy, 9
-; EZ80-NEXT:    add iy, sp
-; EZ80-NEXT:    ld sp, iy
-; EZ80-NEXT:    ld iy, 0
-; EZ80-NEXT:    push iy
-; EZ80-NEXT:    ld iy, 64
-; EZ80-NEXT:    push iy
-; EZ80-NEXT:    ld iy, 0
-; EZ80-NEXT:    push iy
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld (ix - 24), de
+; EZ80-NEXT:    ld (ix - 27), bc
+; EZ80-NEXT:    ld hl, 9
+; EZ80-NEXT:    add hl, sp
+; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    lea hl, iy
+; EZ80-NEXT:    call __llctlz
+; EZ80-NEXT:    ld de, 0
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    ld l, a
+; EZ80-NEXT:    ld bc, -1
+; EZ80-NEXT:    push bc
+; EZ80-NEXT:    push bc
+; EZ80-NEXT:    push bc
+; EZ80-NEXT:    inc.sis bc
+; EZ80-NEXT:    call __lladd
+; EZ80-NEXT:    ld (ix - 9), hl
+; EZ80-NEXT:    ld (ix - 33), de
+; EZ80-NEXT:    ld (ix - 30), bc
+; EZ80-NEXT:    ld hl, 9
+; EZ80-NEXT:    add hl, sp
+; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    ld hl, 64
+; EZ80-NEXT:    ld de, 0
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    or a, a
+; EZ80-NEXT:    sbc hl, hl
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    lea hl, iy
+; EZ80-NEXT:    ld de, (ix - 24)
+; EZ80-NEXT:    ld bc, (ix - 27)
 ; EZ80-NEXT:    call __llcmpu
 ; EZ80-NEXT:    push af
 ; EZ80-NEXT:    ex (sp), hl
-; EZ80-NEXT:    ld (ix - 9), l
+; EZ80-NEXT:    ld (ix - 24), l
 ; EZ80-NEXT:    pop hl
-; EZ80-NEXT:    ld iy, 9
-; EZ80-NEXT:    add iy, sp
-; EZ80-NEXT:    ld sp, iy
+; EZ80-NEXT:    ld hl, 9
+; EZ80-NEXT:    add hl, sp
+; EZ80-NEXT:    ld sp, hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld l, (ix - 9)
+; EZ80-NEXT:    ld l, (ix - 24)
 ; EZ80-NEXT:    ; kill: def $h killed $a
 ; EZ80-NEXT:    ex (sp), hl
 ; EZ80-NEXT:    pop af
 ; EZ80-NEXT:    ccf
 ; EZ80-NEXT:    ; kill: def $a killed $a
 ; EZ80-NEXT:    sbc a, a
-; EZ80-NEXT:    ld iyl, a
-; EZ80-NEXT:    inc iyl
-; EZ80-NEXT:    call __llctlz
-; EZ80-NEXT:    or a, a
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld l, a
-; EZ80-NEXT:    ld a, iyl
-; EZ80-NEXT:    ld de, -1
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    inc de
-; EZ80-NEXT:    ld.sis bc, 0
-; EZ80-NEXT:    call __lladd
-; EZ80-NEXT:    ld (ix - 9), hl
-; EZ80-NEXT:    ld hl, 9
-; EZ80-NEXT:    add hl, sp
-; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    inc a
 ; EZ80-NEXT:    bit 0, a
 ; EZ80-NEXT:    jr z, BB49_2
 ; EZ80-NEXT:  ; %bb.1:
@@ -16048,26 +16045,29 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:  BB49_2:
 ; EZ80-NEXT:    bit 0, a
 ; EZ80-NEXT:    ld iy, 0
+; EZ80-NEXT:    lea bc, iy
 ; EZ80-NEXT:    jr nz, BB49_4
 ; EZ80-NEXT:  ; %bb.3:
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld bc, (ix - 33)
 ; EZ80-NEXT:  BB49_4:
 ; EZ80-NEXT:    bit 0, a
 ; EZ80-NEXT:    ld.sis de, 0
 ; EZ80-NEXT:    ; kill: def $de killed $de def $ude
 ; EZ80-NEXT:    jr nz, BB49_6
 ; EZ80-NEXT:  ; %bb.5:
-; EZ80-NEXT:    ld e, c
-; EZ80-NEXT:    ld d, b
+; EZ80-NEXT:    ld hl, (ix - 30)
+; EZ80-NEXT:    ld e, l
+; EZ80-NEXT:    ld d, h
 ; EZ80-NEXT:  BB49_6:
 ; EZ80-NEXT:    ld hl, 31
 ; EZ80-NEXT:    push de
-; EZ80-NEXT:    push iy
+; EZ80-NEXT:    push bc
 ; EZ80-NEXT:    ld de, (ix - 9)
 ; EZ80-NEXT:    push de
-; EZ80-NEXT:    ld de, 0
-; EZ80-NEXT:    ld.sis bc, 0
+; EZ80-NEXT:    lea de, iy
+; EZ80-NEXT:    ld.sis iy, 0
+; EZ80-NEXT:    ld c, iyl
+; EZ80-NEXT:    ld b, iyh
 ; EZ80-NEXT:    call __llsub
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop iy
@@ -16075,16 +16075,6 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld hl, 9
 ; EZ80-NEXT:    add hl, sp
 ; EZ80-NEXT:    ld sp, hl
-; EZ80-NEXT:    ld hl, 31
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld hl, (ix - 15)
-; EZ80-NEXT:    ld de, (ix - 18)
-; EZ80-NEXT:    ld bc, (ix - 21)
-; EZ80-NEXT:    call __llshl
-; EZ80-NEXT:    ld (ix - 15), hl
-; EZ80-NEXT:    ld (ix - 18), de
-; EZ80-NEXT:    ld (ix - 21), bc
-; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    ld hl, (ix - 9)
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix - 12)
@@ -16131,14 +16121,24 @@ define i64 @sdiv.fix.sat.i64.31(i64, i64) {
 ; EZ80-NEXT:    ld iy, (ix - 24)
 ; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    call __llshrs
+; EZ80-NEXT:    ld (ix - 3), hl
+; EZ80-NEXT:    ld (ix - 6), de
 ; EZ80-NEXT:    ; kill: def $bc killed $bc def $ubc
-; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    push de
+; EZ80-NEXT:    ld (ix - 9), bc
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    ld hl, 31
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix - 15)
 ; EZ80-NEXT:    ld de, (ix - 18)
 ; EZ80-NEXT:    ld bc, (ix - 21)
+; EZ80-NEXT:    call __llshl
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld iy, (ix - 9)
+; EZ80-NEXT:    push iy
+; EZ80-NEXT:    ld iy, (ix - 6)
+; EZ80-NEXT:    push iy
+; EZ80-NEXT:    ld iy, (ix - 3)
+; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    call __lladd
 ; EZ80-NEXT:    ld sp, ix
 ; EZ80-NEXT:    pop ix
@@ -16269,10 +16269,10 @@ define i16 @udiv.fix.sat.i16.8(i16, i16) {
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    ld hl, (ix + 6)
+; EZ80-NEXT:    ld d, 0
 ; EZ80-NEXT:    ld bc, 0
 ; EZ80-NEXT:    ld c, l
 ; EZ80-NEXT:    ld b, h
-; EZ80-NEXT:    ld d, 0
 ; EZ80-NEXT:    ld l, 8
 ; EZ80-NEXT:    ld a, d
 ; EZ80-NEXT:    call __lshl
@@ -16352,10 +16352,10 @@ define i16 @udiv.fix.sat.i16.16(i16, i16) {
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
 ; EZ80-NEXT:    ld hl, (ix + 6)
+; EZ80-NEXT:    ld d, 0
 ; EZ80-NEXT:    ld bc, 0
 ; EZ80-NEXT:    ld c, l
 ; EZ80-NEXT:    ld b, h
-; EZ80-NEXT:    ld d, 0
 ; EZ80-NEXT:    ld l, 16
 ; EZ80-NEXT:    ld a, d
 ; EZ80-NEXT:    call __lshl
@@ -16549,10 +16549,10 @@ define i32 @udiv.fix.sat.i32.16(i32, i32) {
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld iy, (ix + 6)
 ; EZ80-NEXT:    ld a, (ix + 15)
+; EZ80-NEXT:    ld hl, 16
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    ld e, (ix + 9)
 ; EZ80-NEXT:    ld.sis bc, 0
-; EZ80-NEXT:    ld hl, 16
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    lea hl, iy
 ; EZ80-NEXT:    call __llshl
@@ -16775,10 +16775,10 @@ define i32 @udiv.fix.sat.i32.32(i32, i32) {
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld iy, (ix + 6)
 ; EZ80-NEXT:    ld a, (ix + 15)
+; EZ80-NEXT:    ld hl, 32
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    ld e, (ix + 9)
 ; EZ80-NEXT:    ld.sis bc, 0
-; EZ80-NEXT:    ld hl, 32
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    lea hl, iy
 ; EZ80-NEXT:    call __llshl
@@ -16844,7 +16844,7 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; Z80-NEXT:    push ix
 ; Z80-NEXT:    ld ix, 0
 ; Z80-NEXT:    add ix, sp
-; Z80-NEXT:    ld hl, -20
+; Z80-NEXT:    ld hl, -26
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
 ; Z80-NEXT:    push hl
@@ -16872,12 +16872,12 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; Z80-NEXT:    ld c, (ix + 8)
 ; Z80-NEXT:    ld b, (ix + 9)
 ; Z80-NEXT:    call __lldivu
-; Z80-NEXT:    ld (ix - 12), l
-; Z80-NEXT:    ld (ix - 11), h
-; Z80-NEXT:    ld (ix - 14), e
-; Z80-NEXT:    ld (ix - 13), d
-; Z80-NEXT:    ld (ix - 16), c
-; Z80-NEXT:    ld (ix - 15), b
+; Z80-NEXT:    ld (ix - 14), l
+; Z80-NEXT:    ld (ix - 13), h
+; Z80-NEXT:    ld (ix - 16), e
+; Z80-NEXT:    ld (ix - 15), d
+; Z80-NEXT:    ld (ix - 18), c
+; Z80-NEXT:    ld (ix - 17), b
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    ex (sp), hl
 ; Z80-NEXT:    ld (ix - 20), l
@@ -16912,55 +16912,25 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; Z80-NEXT:    ld (ix - 1), h
 ; Z80-NEXT:    ld (ix - 4), e
 ; Z80-NEXT:    ld (ix - 3), d
+; Z80-NEXT:    ld (ix - 6), c
+; Z80-NEXT:    ld (ix - 5), b
 ; Z80-NEXT:    push iy
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 6), l
-; Z80-NEXT:    ld (ix - 5), h
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    ld hl, 10
-; Z80-NEXT:    add hl, sp
-; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    ld de, 0
-; Z80-NEXT:    push de
-; Z80-NEXT:    ld hl, 1
-; Z80-NEXT:    push hl
-; Z80-NEXT:    push de
-; Z80-NEXT:    push de
-; Z80-NEXT:    push iy
-; Z80-NEXT:    ld l, (ix - 2)
-; Z80-NEXT:    ld h, (ix - 1)
-; Z80-NEXT:    ld e, (ix - 4)
-; Z80-NEXT:    ld d, (ix - 3)
-; Z80-NEXT:    call __llcmpu
-; Z80-NEXT:    push af
 ; Z80-NEXT:    ex (sp), hl
 ; Z80-NEXT:    ld (ix - 8), l
+; Z80-NEXT:    ld (ix - 7), h
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 8)
-; Z80-NEXT:    ; kill: def $h killed $a
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    pop af
-; Z80-NEXT:    ccf
-; Z80-NEXT:    ; kill: def $a killed $a
-; Z80-NEXT:    sbc a, a
-; Z80-NEXT:    ld iyl, a
-; Z80-NEXT:    inc iyl
-; Z80-NEXT:    ld l, (ix - 6)
-; Z80-NEXT:    ld h, (ix - 5)
-; Z80-NEXT:    push hl
+; Z80-NEXT:    push iy
 ; Z80-NEXT:    ld l, (ix - 2)
 ; Z80-NEXT:    ld h, (ix - 1)
 ; Z80-NEXT:    ld e, (ix - 4)
 ; Z80-NEXT:    ld d, (ix - 3)
-; Z80-NEXT:    ld (ix - 18), c
-; Z80-NEXT:    ld (ix - 17), b
+; Z80-NEXT:    ld c, (ix - 6)
+; Z80-NEXT:    ld b, (ix - 5)
 ; Z80-NEXT:    call __llctlz
 ; Z80-NEXT:    ld l, a
-; Z80-NEXT:    ld a, iyl
 ; Z80-NEXT:    pop de
 ; Z80-NEXT:    ld h, 0
 ; Z80-NEXT:    ld bc, 0
@@ -16972,109 +16942,121 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; Z80-NEXT:    ld e, c
 ; Z80-NEXT:    ld d, b
 ; Z80-NEXT:    call __lladd
+; Z80-NEXT:    ld (ix - 26), l
+; Z80-NEXT:    ld (ix - 25), h
+; Z80-NEXT:    ld (ix - 12), e
+; Z80-NEXT:    ld (ix - 11), d
+; Z80-NEXT:    ld (ix - 24), c
+; Z80-NEXT:    ld (ix - 23), b
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 8), l
-; Z80-NEXT:    ld (ix - 7), h
+; Z80-NEXT:    ld (ix - 22), l
+; Z80-NEXT:    ld (ix - 21), h
 ; Z80-NEXT:    pop hl
-; Z80-NEXT:    ld iy, 10
-; Z80-NEXT:    add iy, sp
-; Z80-NEXT:    ld sp, iy
-; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld iy, 32
-; Z80-NEXT:    jr nz, BB55_2
-; Z80-NEXT:  ; %bb.1:
-; Z80-NEXT:    ex de, hl
-; Z80-NEXT:    ld iyl, e
-; Z80-NEXT:    ld iyh, d
-; Z80-NEXT:    ex de, hl
-; Z80-NEXT:  BB55_2:
-; Z80-NEXT:    push iy
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 10), l
-; Z80-NEXT:    ld (ix - 9), h
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld iy, 0
-; Z80-NEXT:    ex de, hl
-; Z80-NEXT:    ld e, iyl
-; Z80-NEXT:    ld d, iyh
-; Z80-NEXT:    ex de, hl
-; Z80-NEXT:    jr nz, BB55_4
-; Z80-NEXT:  ; %bb.3:
-; Z80-NEXT:    ex de, hl
-; Z80-NEXT:  BB55_4:
-; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld e, iyl
-; Z80-NEXT:    ld d, iyh
-; Z80-NEXT:    jr nz, BB55_6
-; Z80-NEXT:  ; %bb.5:
-; Z80-NEXT:    ld e, c
-; Z80-NEXT:    ld d, b
-; Z80-NEXT:  BB55_6:
-; Z80-NEXT:    bit 0, a
-; Z80-NEXT:    ld c, iyl
-; Z80-NEXT:    ld b, iyh
-; Z80-NEXT:    jr nz, BB55_8
-; Z80-NEXT:  ; %bb.7:
-; Z80-NEXT:    ld c, (ix - 8)
-; Z80-NEXT:    ld b, (ix - 7)
-; Z80-NEXT:  BB55_8:
-; Z80-NEXT:    push bc
-; Z80-NEXT:    push de
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 10)
-; Z80-NEXT:    ld h, (ix - 9)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    push iy
-; Z80-NEXT:    ld hl, 32
-; Z80-NEXT:    ld e, iyl
-; Z80-NEXT:    ld d, iyh
-; Z80-NEXT:    ld c, iyl
-; Z80-NEXT:    ld b, iyh
-; Z80-NEXT:    call __llsub
-; Z80-NEXT:    ld (ix - 8), l
-; Z80-NEXT:    ld (ix - 7), h
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    ld hl, 32
+; Z80-NEXT:    ld iy, 32
+; Z80-NEXT:    ld hl, 1
+; Z80-NEXT:    ld de, 0
+; Z80-NEXT:    push de
 ; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 20)
-; Z80-NEXT:    ld h, (ix - 19)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 12)
-; Z80-NEXT:    ld h, (ix - 11)
-; Z80-NEXT:    ld e, (ix - 14)
-; Z80-NEXT:    ld d, (ix - 13)
-; Z80-NEXT:    ld c, (ix - 16)
-; Z80-NEXT:    ld b, (ix - 15)
-; Z80-NEXT:    call __llshl
-; Z80-NEXT:    ld (ix - 12), l
-; Z80-NEXT:    ld (ix - 11), h
-; Z80-NEXT:    ld (ix - 14), e
-; Z80-NEXT:    ld (ix - 13), d
-; Z80-NEXT:    ld (ix - 16), c
-; Z80-NEXT:    ld (ix - 15), b
-; Z80-NEXT:    push iy
-; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 20), l
-; Z80-NEXT:    ld (ix - 19), h
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    ld l, (ix - 10)
-; Z80-NEXT:    ld h, (ix - 9)
-; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 6)
-; Z80-NEXT:    ld h, (ix - 5)
+; Z80-NEXT:    push de
+; Z80-NEXT:    push de
+; Z80-NEXT:    ld l, (ix - 8)
+; Z80-NEXT:    ld h, (ix - 7)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld l, (ix - 2)
 ; Z80-NEXT:    ld h, (ix - 1)
 ; Z80-NEXT:    ld e, (ix - 4)
 ; Z80-NEXT:    ld d, (ix - 3)
-; Z80-NEXT:    ld c, (ix - 18)
-; Z80-NEXT:    ld b, (ix - 17)
+; Z80-NEXT:    ld c, (ix - 6)
+; Z80-NEXT:    ld b, (ix - 5)
+; Z80-NEXT:    call __llcmpu
+; Z80-NEXT:    push af
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    ld (ix - 10), l
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld hl, 10
+; Z80-NEXT:    add hl, sp
+; Z80-NEXT:    ld sp, hl
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 10)
+; Z80-NEXT:    ; kill: def $h killed $a
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    pop af
+; Z80-NEXT:    ccf
+; Z80-NEXT:    ; kill: def $a killed $a
+; Z80-NEXT:    sbc a, a
+; Z80-NEXT:    inc a
+; Z80-NEXT:    bit 0, a
+; Z80-NEXT:    ex de, hl
+; Z80-NEXT:    ld e, iyl
+; Z80-NEXT:    ld d, iyh
+; Z80-NEXT:    ex de, hl
+; Z80-NEXT:    jr nz, BB55_2
+; Z80-NEXT:  ; %bb.1:
+; Z80-NEXT:    ld l, (ix - 26)
+; Z80-NEXT:    ld h, (ix - 25)
+; Z80-NEXT:  BB55_2:
+; Z80-NEXT:    bit 0, a
+; Z80-NEXT:    ld bc, 0
+; Z80-NEXT:    ld iyl, c
+; Z80-NEXT:    ld iyh, b
+; Z80-NEXT:    jr nz, BB55_4
+; Z80-NEXT:  ; %bb.3:
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    pop iy
+; Z80-NEXT:  BB55_4:
+; Z80-NEXT:    ld (ix - 12), l
+; Z80-NEXT:    ld (ix - 11), h
+; Z80-NEXT:    bit 0, a
+; Z80-NEXT:    ld e, c
+; Z80-NEXT:    ld d, b
+; Z80-NEXT:    jr nz, BB55_6
+; Z80-NEXT:  ; %bb.5:
+; Z80-NEXT:    ld e, (ix - 24)
+; Z80-NEXT:    ld d, (ix - 23)
+; Z80-NEXT:  BB55_6:
+; Z80-NEXT:    bit 0, a
+; Z80-NEXT:    ld l, c
+; Z80-NEXT:    ld h, b
+; Z80-NEXT:    jr nz, BB55_8
+; Z80-NEXT:  ; %bb.7:
+; Z80-NEXT:    ld l, (ix - 22)
+; Z80-NEXT:    ld h, (ix - 21)
+; Z80-NEXT:  BB55_8:
+; Z80-NEXT:    push hl
+; Z80-NEXT:    push de
+; Z80-NEXT:    push iy
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    push bc
+; Z80-NEXT:    ld hl, 32
+; Z80-NEXT:    ld e, c
+; Z80-NEXT:    ld d, b
+; Z80-NEXT:    call __llsub
+; Z80-NEXT:    ld (ix - 10), l
+; Z80-NEXT:    ld (ix - 9), h
+; Z80-NEXT:    ld hl, 10
+; Z80-NEXT:    add hl, sp
+; Z80-NEXT:    ld sp, hl
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 8)
+; Z80-NEXT:    ld h, (ix - 7)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 2)
+; Z80-NEXT:    ld h, (ix - 1)
+; Z80-NEXT:    ld e, (ix - 4)
+; Z80-NEXT:    ld d, (ix - 3)
+; Z80-NEXT:    ld c, (ix - 6)
+; Z80-NEXT:    ld b, (ix - 5)
 ; Z80-NEXT:    call __llshl
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
@@ -17084,13 +17066,13 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; Z80-NEXT:    ld (ix - 5), b
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    ex (sp), hl
-; Z80-NEXT:    ld (ix - 10), l
-; Z80-NEXT:    ld (ix - 9), h
+; Z80-NEXT:    ld (ix - 8), l
+; Z80-NEXT:    ld (ix - 7), h
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    pop hl
-; Z80-NEXT:    ld l, (ix - 8)
-; Z80-NEXT:    ld h, (ix - 7)
+; Z80-NEXT:    ld l, (ix - 10)
+; Z80-NEXT:    ld h, (ix - 9)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld bc, 0
 ; Z80-NEXT:    push bc
@@ -17098,25 +17080,25 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; Z80-NEXT:    ld e, c
 ; Z80-NEXT:    ld d, b
 ; Z80-NEXT:    call __llshl
-; Z80-NEXT:    ld (ix - 18), l
-; Z80-NEXT:    ld (ix - 17), h
+; Z80-NEXT:    ld (ix - 12), l
+; Z80-NEXT:    ld (ix - 11), h
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    ld hl, 1
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    push iy
-; Z80-NEXT:    ld l, (ix - 18)
-; Z80-NEXT:    ld h, (ix - 17)
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
 ; Z80-NEXT:    call __llshru
-; Z80-NEXT:    ld (ix - 18), l
-; Z80-NEXT:    ld (ix - 17), h
+; Z80-NEXT:    ld (ix - 12), l
+; Z80-NEXT:    ld (ix - 11), h
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    pop hl
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    push bc
 ; Z80-NEXT:    push de
-; Z80-NEXT:    ld l, (ix - 18)
-; Z80-NEXT:    ld h, (ix - 17)
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld l, (ix + 18)
 ; Z80-NEXT:    ld h, (ix + 19)
@@ -17128,19 +17110,19 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; Z80-NEXT:    ld c, (ix + 16)
 ; Z80-NEXT:    ld b, (ix + 17)
 ; Z80-NEXT:    call __lladd
-; Z80-NEXT:    ld (ix - 18), l
-; Z80-NEXT:    ld (ix - 17), h
+; Z80-NEXT:    ld (ix - 12), l
+; Z80-NEXT:    ld (ix - 11), h
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    push bc
 ; Z80-NEXT:    push de
-; Z80-NEXT:    ld l, (ix - 18)
-; Z80-NEXT:    ld h, (ix - 17)
+; Z80-NEXT:    ld l, (ix - 12)
+; Z80-NEXT:    ld h, (ix - 11)
 ; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 10)
-; Z80-NEXT:    ld h, (ix - 9)
+; Z80-NEXT:    ld l, (ix - 8)
+; Z80-NEXT:    ld h, (ix - 7)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld l, (ix - 2)
 ; Z80-NEXT:    ld h, (ix - 1)
@@ -17154,8 +17136,8 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; Z80-NEXT:    ld hl, 10
 ; Z80-NEXT:    add hl, sp
 ; Z80-NEXT:    ld sp, hl
-; Z80-NEXT:    ld l, (ix - 8)
-; Z80-NEXT:    ld h, (ix - 7)
+; Z80-NEXT:    ld l, (ix - 10)
+; Z80-NEXT:    ld h, (ix - 9)
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    push iy
 ; Z80-NEXT:    ld l, (ix - 2)
@@ -17163,23 +17145,48 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; Z80-NEXT:    call __llshru
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
-; Z80-NEXT:    pop hl
-; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld (ix - 4), e
+; Z80-NEXT:    ld (ix - 3), d
+; Z80-NEXT:    ld (ix - 6), c
+; Z80-NEXT:    ld (ix - 5), b
 ; Z80-NEXT:    push iy
-; Z80-NEXT:    push bc
-; Z80-NEXT:    push de
-; Z80-NEXT:    ld l, (ix - 2)
-; Z80-NEXT:    ld h, (ix - 1)
+; Z80-NEXT:    ex (sp), hl
+; Z80-NEXT:    ld (ix - 8), l
+; Z80-NEXT:    ld (ix - 7), h
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld hl, 32
 ; Z80-NEXT:    push hl
 ; Z80-NEXT:    ld l, (ix - 20)
 ; Z80-NEXT:    ld h, (ix - 19)
 ; Z80-NEXT:    push hl
-; Z80-NEXT:    ld l, (ix - 12)
-; Z80-NEXT:    ld h, (ix - 11)
-; Z80-NEXT:    ld e, (ix - 14)
-; Z80-NEXT:    ld d, (ix - 13)
-; Z80-NEXT:    ld c, (ix - 16)
-; Z80-NEXT:    ld b, (ix - 15)
+; Z80-NEXT:    ld l, (ix - 14)
+; Z80-NEXT:    ld h, (ix - 13)
+; Z80-NEXT:    ld e, (ix - 16)
+; Z80-NEXT:    ld d, (ix - 15)
+; Z80-NEXT:    ld c, (ix - 18)
+; Z80-NEXT:    ld b, (ix - 17)
+; Z80-NEXT:    call __llshl
+; Z80-NEXT:    ld (ix - 10), l
+; Z80-NEXT:    ld (ix - 9), h
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    pop hl
+; Z80-NEXT:    ld l, (ix - 8)
+; Z80-NEXT:    ld h, (ix - 7)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 6)
+; Z80-NEXT:    ld h, (ix - 5)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 4)
+; Z80-NEXT:    ld h, (ix - 3)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    ld l, (ix - 2)
+; Z80-NEXT:    ld h, (ix - 1)
+; Z80-NEXT:    push hl
+; Z80-NEXT:    push iy
+; Z80-NEXT:    ld l, (ix - 10)
+; Z80-NEXT:    ld h, (ix - 9)
 ; Z80-NEXT:    call __lladd
 ; Z80-NEXT:    ld (ix - 2), l
 ; Z80-NEXT:    ld (ix - 1), h
@@ -17197,7 +17204,7 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    push ix
 ; EZ80-CODE16-NEXT:    ld ix, 0
 ; EZ80-CODE16-NEXT:    add ix, sp
-; EZ80-CODE16-NEXT:    lea hl, ix - 20
+; EZ80-CODE16-NEXT:    lea hl, ix - 26
 ; EZ80-CODE16-NEXT:    ld sp, hl
 ; EZ80-CODE16-NEXT:    ld iy, (ix + 12)
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 14)
@@ -17213,9 +17220,9 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld de, (ix + 6)
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 8)
 ; EZ80-CODE16-NEXT:    call __lldivu
-; EZ80-CODE16-NEXT:    ld (ix - 12), hl
-; EZ80-CODE16-NEXT:    ld (ix - 14), de
-; EZ80-CODE16-NEXT:    ld (ix - 16), bc
+; EZ80-CODE16-NEXT:    ld (ix - 14), hl
+; EZ80-CODE16-NEXT:    ld (ix - 16), de
+; EZ80-CODE16-NEXT:    ld (ix - 18), bc
 ; EZ80-CODE16-NEXT:    ld (ix - 20), iy
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
@@ -17236,45 +17243,17 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    call __llremu
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
 ; EZ80-CODE16-NEXT:    ld (ix - 4), de
-; EZ80-CODE16-NEXT:    ld (ix - 6), iy
+; EZ80-CODE16-NEXT:    ld (ix - 6), bc
+; EZ80-CODE16-NEXT:    ld (ix - 8), iy
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld de, 0
-; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    ld hl, 1
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    push de
 ; EZ80-CODE16-NEXT:    push iy
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    ld de, (ix - 4)
-; EZ80-CODE16-NEXT:    call __llcmpu
-; EZ80-CODE16-NEXT:    push af
-; EZ80-CODE16-NEXT:    ex (sp), hl
-; EZ80-CODE16-NEXT:    ld (ix - 8), l
-; EZ80-CODE16-NEXT:    pop hl
-; EZ80-CODE16-NEXT:    ld hl, 10
-; EZ80-CODE16-NEXT:    add hl, sp
-; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld l, (ix - 8)
-; EZ80-CODE16-NEXT:    ; kill: def $h killed $a
-; EZ80-CODE16-NEXT:    ex (sp), hl
-; EZ80-CODE16-NEXT:    pop af
-; EZ80-CODE16-NEXT:    ccf
-; EZ80-CODE16-NEXT:    ; kill: def $a killed $a
-; EZ80-CODE16-NEXT:    sbc a, a
-; EZ80-CODE16-NEXT:    ld iyl, a
-; EZ80-CODE16-NEXT:    inc iyl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 6)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
-; EZ80-CODE16-NEXT:    ld de, (ix - 4)
-; EZ80-CODE16-NEXT:    ld (ix - 18), bc
+; EZ80-CODE16-NEXT:    ld bc, (ix - 6)
 ; EZ80-CODE16-NEXT:    call __llctlz
 ; EZ80-CODE16-NEXT:    ld l, a
-; EZ80-CODE16-NEXT:    ld a, iyl
 ; EZ80-CODE16-NEXT:    pop de
 ; EZ80-CODE16-NEXT:    ld h, 0
 ; EZ80-CODE16-NEXT:    ld bc, 0
@@ -17286,85 +17265,101 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld e, c
 ; EZ80-CODE16-NEXT:    ld d, b
 ; EZ80-CODE16-NEXT:    call __lladd
-; EZ80-CODE16-NEXT:    ld (ix - 8), iy
-; EZ80-CODE16-NEXT:    ld iy, 10
-; EZ80-CODE16-NEXT:    add iy, sp
-; EZ80-CODE16-NEXT:    ld sp, iy
-; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    ld iy, 32
-; EZ80-CODE16-NEXT:    jr nz, BB55_2
-; EZ80-CODE16-NEXT:  ; %bb.1:
-; EZ80-CODE16-NEXT:    ex de, hl
-; EZ80-CODE16-NEXT:    ld iyl, e
-; EZ80-CODE16-NEXT:    ld iyh, d
-; EZ80-CODE16-NEXT:    ex de, hl
-; EZ80-CODE16-NEXT:  BB55_2:
-; EZ80-CODE16-NEXT:    ld (ix - 10), iy
-; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    ld iy, 0
-; EZ80-CODE16-NEXT:    lea hl, iy
-; EZ80-CODE16-NEXT:    jr nz, BB55_4
-; EZ80-CODE16-NEXT:  ; %bb.3:
-; EZ80-CODE16-NEXT:    ex de, hl
-; EZ80-CODE16-NEXT:  BB55_4:
-; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    lea de, iy
-; EZ80-CODE16-NEXT:    jr nz, BB55_6
-; EZ80-CODE16-NEXT:  ; %bb.5:
-; EZ80-CODE16-NEXT:    ld e, c
-; EZ80-CODE16-NEXT:    ld d, b
-; EZ80-CODE16-NEXT:  BB55_6:
-; EZ80-CODE16-NEXT:    bit 0, a
-; EZ80-CODE16-NEXT:    lea bc, iy
-; EZ80-CODE16-NEXT:    jr nz, BB55_8
-; EZ80-CODE16-NEXT:  ; %bb.7:
-; EZ80-CODE16-NEXT:    ld bc, (ix - 8)
-; EZ80-CODE16-NEXT:  BB55_8:
-; EZ80-CODE16-NEXT:    push bc
-; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    push iy
-; EZ80-CODE16-NEXT:    ld hl, 32
-; EZ80-CODE16-NEXT:    lea de, iy
-; EZ80-CODE16-NEXT:    lea bc, iy
-; EZ80-CODE16-NEXT:    call __llsub
-; EZ80-CODE16-NEXT:    ld (ix - 8), hl
+; EZ80-CODE16-NEXT:    ld (ix - 26), hl
+; EZ80-CODE16-NEXT:    ld (ix - 12), de
+; EZ80-CODE16-NEXT:    ld (ix - 24), bc
+; EZ80-CODE16-NEXT:    ld (ix - 22), iy
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld hl, 32
+; EZ80-CODE16-NEXT:    ld iy, 32
+; EZ80-CODE16-NEXT:    ld hl, 1
+; EZ80-CODE16-NEXT:    ld de, 0
+; EZ80-CODE16-NEXT:    push de
 ; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 20)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
-; EZ80-CODE16-NEXT:    ld de, (ix - 14)
-; EZ80-CODE16-NEXT:    ld bc, (ix - 16)
-; EZ80-CODE16-NEXT:    call __llshl
-; EZ80-CODE16-NEXT:    ld (ix - 12), hl
-; EZ80-CODE16-NEXT:    ld (ix - 14), de
-; EZ80-CODE16-NEXT:    ld (ix - 16), bc
-; EZ80-CODE16-NEXT:    ld (ix - 20), iy
-; EZ80-CODE16-NEXT:    ld hl, 4
-; EZ80-CODE16-NEXT:    add hl, sp
-; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
-; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 6)
+; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    ld de, (ix - 4)
-; EZ80-CODE16-NEXT:    ld bc, (ix - 18)
+; EZ80-CODE16-NEXT:    ld bc, (ix - 6)
+; EZ80-CODE16-NEXT:    call __llcmpu
+; EZ80-CODE16-NEXT:    push af
+; EZ80-CODE16-NEXT:    ex (sp), hl
+; EZ80-CODE16-NEXT:    ld (ix - 10), l
+; EZ80-CODE16-NEXT:    pop hl
+; EZ80-CODE16-NEXT:    ld hl, 10
+; EZ80-CODE16-NEXT:    add hl, sp
+; EZ80-CODE16-NEXT:    ld sp, hl
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld l, (ix - 10)
+; EZ80-CODE16-NEXT:    ; kill: def $h killed $a
+; EZ80-CODE16-NEXT:    ex (sp), hl
+; EZ80-CODE16-NEXT:    pop af
+; EZ80-CODE16-NEXT:    ccf
+; EZ80-CODE16-NEXT:    ; kill: def $a killed $a
+; EZ80-CODE16-NEXT:    sbc a, a
+; EZ80-CODE16-NEXT:    inc a
+; EZ80-CODE16-NEXT:    bit 0, a
+; EZ80-CODE16-NEXT:    lea hl, iy
+; EZ80-CODE16-NEXT:    jr nz, BB55_2
+; EZ80-CODE16-NEXT:  ; %bb.1:
+; EZ80-CODE16-NEXT:    ld hl, (ix - 26)
+; EZ80-CODE16-NEXT:  BB55_2:
+; EZ80-CODE16-NEXT:    bit 0, a
+; EZ80-CODE16-NEXT:    ld bc, 0
+; EZ80-CODE16-NEXT:    ld iyl, c
+; EZ80-CODE16-NEXT:    ld iyh, b
+; EZ80-CODE16-NEXT:    jr nz, BB55_4
+; EZ80-CODE16-NEXT:  ; %bb.3:
+; EZ80-CODE16-NEXT:    ld iy, (ix - 12)
+; EZ80-CODE16-NEXT:  BB55_4:
+; EZ80-CODE16-NEXT:    ld (ix - 12), hl
+; EZ80-CODE16-NEXT:    bit 0, a
+; EZ80-CODE16-NEXT:    ld e, c
+; EZ80-CODE16-NEXT:    ld d, b
+; EZ80-CODE16-NEXT:    jr nz, BB55_6
+; EZ80-CODE16-NEXT:  ; %bb.5:
+; EZ80-CODE16-NEXT:    ld de, (ix - 24)
+; EZ80-CODE16-NEXT:  BB55_6:
+; EZ80-CODE16-NEXT:    bit 0, a
+; EZ80-CODE16-NEXT:    ld l, c
+; EZ80-CODE16-NEXT:    ld h, b
+; EZ80-CODE16-NEXT:    jr nz, BB55_8
+; EZ80-CODE16-NEXT:  ; %bb.7:
+; EZ80-CODE16-NEXT:    ld hl, (ix - 22)
+; EZ80-CODE16-NEXT:  BB55_8:
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    push de
+; EZ80-CODE16-NEXT:    push iy
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    push bc
+; EZ80-CODE16-NEXT:    ld hl, 32
+; EZ80-CODE16-NEXT:    ld e, c
+; EZ80-CODE16-NEXT:    ld d, b
+; EZ80-CODE16-NEXT:    call __llsub
+; EZ80-CODE16-NEXT:    ld (ix - 10), hl
+; EZ80-CODE16-NEXT:    ld hl, 10
+; EZ80-CODE16-NEXT:    add hl, sp
+; EZ80-CODE16-NEXT:    ld sp, hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
+; EZ80-CODE16-NEXT:    ld de, (ix - 4)
+; EZ80-CODE16-NEXT:    ld bc, (ix - 6)
 ; EZ80-CODE16-NEXT:    call __llshl
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
 ; EZ80-CODE16-NEXT:    ld (ix - 4), de
 ; EZ80-CODE16-NEXT:    ld (ix - 6), bc
-; EZ80-CODE16-NEXT:    ld (ix - 10), iy
+; EZ80-CODE16-NEXT:    ld (ix - 8), iy
 ; EZ80-CODE16-NEXT:    ld hl, 4
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld bc, 0
 ; EZ80-CODE16-NEXT:    push bc
@@ -17372,23 +17367,23 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld e, c
 ; EZ80-CODE16-NEXT:    ld d, b
 ; EZ80-CODE16-NEXT:    call __llshl
-; EZ80-CODE16-NEXT:    ld (ix - 18), hl
+; EZ80-CODE16-NEXT:    ld (ix - 12), hl
 ; EZ80-CODE16-NEXT:    ld hl, 4
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
 ; EZ80-CODE16-NEXT:    ld hl, 1
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    push iy
-; EZ80-CODE16-NEXT:    ld hl, (ix - 18)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
 ; EZ80-CODE16-NEXT:    call __llshru
-; EZ80-CODE16-NEXT:    ld (ix - 18), hl
+; EZ80-CODE16-NEXT:    ld (ix - 12), hl
 ; EZ80-CODE16-NEXT:    ld hl, 4
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
 ; EZ80-CODE16-NEXT:    push iy
 ; EZ80-CODE16-NEXT:    push bc
 ; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    ld hl, (ix - 18)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix + 18)
 ; EZ80-CODE16-NEXT:    push hl
@@ -17396,16 +17391,16 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld de, (ix + 14)
 ; EZ80-CODE16-NEXT:    ld bc, (ix + 16)
 ; EZ80-CODE16-NEXT:    call __lladd
-; EZ80-CODE16-NEXT:    ld (ix - 18), hl
+; EZ80-CODE16-NEXT:    ld (ix - 12), hl
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
 ; EZ80-CODE16-NEXT:    push iy
 ; EZ80-CODE16-NEXT:    push bc
 ; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    ld hl, (ix - 18)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
 ; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    ld de, (ix - 4)
@@ -17415,25 +17410,40 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; EZ80-CODE16-NEXT:    ld hl, 10
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    push iy
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
 ; EZ80-CODE16-NEXT:    call __llshru
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
+; EZ80-CODE16-NEXT:    ld (ix - 4), de
+; EZ80-CODE16-NEXT:    ld (ix - 6), bc
+; EZ80-CODE16-NEXT:    ld (ix - 8), iy
 ; EZ80-CODE16-NEXT:    ld hl, 4
 ; EZ80-CODE16-NEXT:    add hl, sp
 ; EZ80-CODE16-NEXT:    ld sp, hl
-; EZ80-CODE16-NEXT:    push iy
-; EZ80-CODE16-NEXT:    push bc
-; EZ80-CODE16-NEXT:    push de
-; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
+; EZ80-CODE16-NEXT:    ld hl, 32
 ; EZ80-CODE16-NEXT:    push hl
 ; EZ80-CODE16-NEXT:    ld hl, (ix - 20)
 ; EZ80-CODE16-NEXT:    push hl
-; EZ80-CODE16-NEXT:    ld hl, (ix - 12)
-; EZ80-CODE16-NEXT:    ld de, (ix - 14)
-; EZ80-CODE16-NEXT:    ld bc, (ix - 16)
+; EZ80-CODE16-NEXT:    ld hl, (ix - 14)
+; EZ80-CODE16-NEXT:    ld de, (ix - 16)
+; EZ80-CODE16-NEXT:    ld bc, (ix - 18)
+; EZ80-CODE16-NEXT:    call __llshl
+; EZ80-CODE16-NEXT:    ld (ix - 10), hl
+; EZ80-CODE16-NEXT:    ld hl, 4
+; EZ80-CODE16-NEXT:    add hl, sp
+; EZ80-CODE16-NEXT:    ld sp, hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 8)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 6)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 4)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    ld hl, (ix - 2)
+; EZ80-CODE16-NEXT:    push hl
+; EZ80-CODE16-NEXT:    push iy
+; EZ80-CODE16-NEXT:    ld hl, (ix - 10)
 ; EZ80-CODE16-NEXT:    call __lladd
 ; EZ80-CODE16-NEXT:    ld (ix - 2), hl
 ; EZ80-CODE16-NEXT:    ld hl, 10
@@ -17449,7 +17459,7 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; EZ80-NEXT:    push ix
 ; EZ80-NEXT:    ld ix, 0
 ; EZ80-NEXT:    add ix, sp
-; EZ80-NEXT:    lea hl, ix - 21
+; EZ80-NEXT:    lea hl, ix - 30
 ; EZ80-NEXT:    ld sp, hl
 ; EZ80-NEXT:    ld bc, (ix + 12)
 ; EZ80-NEXT:    ld de, (ix + 15)
@@ -17480,106 +17490,102 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; EZ80-NEXT:    call __llremu
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    ld (ix - 3), iy
+; EZ80-NEXT:    ld (ix - 3), de
+; EZ80-NEXT:    ld (ix - 6), bc
 ; EZ80-NEXT:    ld hl, 9
 ; EZ80-NEXT:    add hl, sp
 ; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    lea hl, iy
+; EZ80-NEXT:    call __llctlz
+; EZ80-NEXT:    ld de, 0
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    ld l, a
+; EZ80-NEXT:    ld bc, 0
+; EZ80-NEXT:    push bc
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    call __lladd
+; EZ80-NEXT:    ld (ix - 30), hl
+; EZ80-NEXT:    ld (ix - 27), de
+; EZ80-NEXT:    ld (ix - 24), bc
+; EZ80-NEXT:    ld hl, 9
+; EZ80-NEXT:    add hl, sp
+; EZ80-NEXT:    ld sp, hl
+; EZ80-NEXT:    ld hl, 256
+; EZ80-NEXT:    ld de, 0
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    or a, a
 ; EZ80-NEXT:    sbc hl, hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld hl, 256
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    push hl
+; EZ80-NEXT:    ld (ix - 18), iy
 ; EZ80-NEXT:    lea hl, iy
+; EZ80-NEXT:    ld de, (ix - 3)
+; EZ80-NEXT:    ld bc, (ix - 6)
 ; EZ80-NEXT:    call __llcmpu
 ; EZ80-NEXT:    push af
 ; EZ80-NEXT:    ex (sp), hl
-; EZ80-NEXT:    ld (ix - 6), l
+; EZ80-NEXT:    ld (ix - 21), l
 ; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    ld hl, 9
 ; EZ80-NEXT:    add hl, sp
 ; EZ80-NEXT:    ld sp, hl
 ; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld l, (ix - 6)
+; EZ80-NEXT:    ld l, (ix - 21)
 ; EZ80-NEXT:    ; kill: def $h killed $a
 ; EZ80-NEXT:    ex (sp), hl
 ; EZ80-NEXT:    pop af
 ; EZ80-NEXT:    ccf
 ; EZ80-NEXT:    ; kill: def $a killed $a
 ; EZ80-NEXT:    sbc a, a
-; EZ80-NEXT:    ld iyl, a
-; EZ80-NEXT:    inc iyl
-; EZ80-NEXT:    ld hl, (ix - 3)
-; EZ80-NEXT:    ld (ix - 18), de
-; EZ80-NEXT:    ld (ix - 21), bc
-; EZ80-NEXT:    call __llctlz
-; EZ80-NEXT:    or a, a
-; EZ80-NEXT:    sbc hl, hl
-; EZ80-NEXT:    ld l, a
-; EZ80-NEXT:    ld a, iyl
-; EZ80-NEXT:    ld de, 0
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    push de
-; EZ80-NEXT:    ld.sis bc, 0
-; EZ80-NEXT:    call __lladd
-; EZ80-NEXT:    ld iy, 9
-; EZ80-NEXT:    add iy, sp
-; EZ80-NEXT:    ld sp, iy
+; EZ80-NEXT:    inc a
 ; EZ80-NEXT:    bit 0, a
 ; EZ80-NEXT:    ld iy, 32
+; EZ80-NEXT:    lea bc, iy
 ; EZ80-NEXT:    jr nz, BB55_2
 ; EZ80-NEXT:  ; %bb.1:
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld iy, (ix - 30)
 ; EZ80-NEXT:  BB55_2:
 ; EZ80-NEXT:    bit 0, a
 ; EZ80-NEXT:    ld hl, 0
 ; EZ80-NEXT:    jr nz, BB55_4
 ; EZ80-NEXT:  ; %bb.3:
-; EZ80-NEXT:    ex de, hl
+; EZ80-NEXT:    ld hl, (ix - 27)
 ; EZ80-NEXT:  BB55_4:
 ; EZ80-NEXT:    bit 0, a
 ; EZ80-NEXT:    ld.sis de, 0
 ; EZ80-NEXT:    ; kill: def $de killed $de def $ude
-; EZ80-NEXT:    jr nz, BB55_6
+; EZ80-NEXT:    jp nz, BB55_6
 ; EZ80-NEXT:  ; %bb.5:
-; EZ80-NEXT:    ld e, c
-; EZ80-NEXT:    ld d, b
+; EZ80-NEXT:    ld de, (ix - 24)
+; EZ80-NEXT:    ; kill: def $de killed $de def $ude
 ; EZ80-NEXT:  BB55_6:
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    push iy
-; EZ80-NEXT:    ld hl, 32
+; EZ80-NEXT:    push bc
+; EZ80-NEXT:    pop hl
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    ld.sis bc, 0
 ; EZ80-NEXT:    call __llsub
-; EZ80-NEXT:    ld (ix - 6), hl
+; EZ80-NEXT:    lea de, iy
+; EZ80-NEXT:    push hl
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld (ix - 21), iy
 ; EZ80-NEXT:    ld hl, 9
 ; EZ80-NEXT:    add hl, sp
 ; EZ80-NEXT:    ld sp, hl
-; EZ80-NEXT:    ld hl, 32
-; EZ80-NEXT:    push hl
-; EZ80-NEXT:    ld hl, (ix - 9)
-; EZ80-NEXT:    ld de, (ix - 12)
-; EZ80-NEXT:    ld bc, (ix - 15)
-; EZ80-NEXT:    call __llshl
-; EZ80-NEXT:    ld (ix - 9), hl
-; EZ80-NEXT:    ld (ix - 12), de
-; EZ80-NEXT:    ld (ix - 15), bc
-; EZ80-NEXT:    pop hl
-; EZ80-NEXT:    push iy
-; EZ80-NEXT:    ld hl, (ix - 3)
-; EZ80-NEXT:    ld de, (ix - 18)
-; EZ80-NEXT:    ld bc, (ix - 21)
+; EZ80-NEXT:    push de
+; EZ80-NEXT:    ld hl, (ix - 18)
+; EZ80-NEXT:    ld de, (ix - 3)
+; EZ80-NEXT:    ld bc, (ix - 6)
 ; EZ80-NEXT:    call __llshl
 ; EZ80-NEXT:    ld (ix - 3), hl
-; EZ80-NEXT:    ld (ix - 18), de
-; EZ80-NEXT:    ld (ix - 21), bc
+; EZ80-NEXT:    ld (ix - 6), de
+; EZ80-NEXT:    ld (ix - 18), bc
 ; EZ80-NEXT:    pop hl
-; EZ80-NEXT:    ld hl, (ix - 6)
-; EZ80-NEXT:    push hl
+; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    ld hl, 1
 ; EZ80-NEXT:    ld de, 0
 ; EZ80-NEXT:    ld.sis bc, 0
@@ -17606,23 +17612,33 @@ define i64 @udiv.fix.sat.i64.32(i64, i64) {
 ; EZ80-NEXT:    push de
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix - 3)
-; EZ80-NEXT:    ld de, (ix - 18)
-; EZ80-NEXT:    ld bc, (ix - 21)
+; EZ80-NEXT:    ld de, (ix - 6)
+; EZ80-NEXT:    ld bc, (ix - 18)
 ; EZ80-NEXT:    call __lldivu
 ; EZ80-NEXT:    ld iy, 9
 ; EZ80-NEXT:    add iy, sp
 ; EZ80-NEXT:    ld sp, iy
-; EZ80-NEXT:    ld iy, (ix - 6)
+; EZ80-NEXT:    ld iy, (ix - 21)
 ; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    call __llshru
+; EZ80-NEXT:    ld (ix - 3), hl
+; EZ80-NEXT:    ld (ix - 6), de
 ; EZ80-NEXT:    ; kill: def $bc killed $bc def $ubc
-; EZ80-NEXT:    pop iy
-; EZ80-NEXT:    push bc
-; EZ80-NEXT:    push de
+; EZ80-NEXT:    ld (ix - 18), bc
+; EZ80-NEXT:    pop hl
+; EZ80-NEXT:    ld hl, 32
 ; EZ80-NEXT:    push hl
 ; EZ80-NEXT:    ld hl, (ix - 9)
 ; EZ80-NEXT:    ld de, (ix - 12)
 ; EZ80-NEXT:    ld bc, (ix - 15)
+; EZ80-NEXT:    call __llshl
+; EZ80-NEXT:    pop iy
+; EZ80-NEXT:    ld iy, (ix - 18)
+; EZ80-NEXT:    push iy
+; EZ80-NEXT:    ld iy, (ix - 6)
+; EZ80-NEXT:    push iy
+; EZ80-NEXT:    ld iy, (ix - 3)
+; EZ80-NEXT:    push iy
 ; EZ80-NEXT:    call __lladd
 ; EZ80-NEXT:    ld sp, ix
 ; EZ80-NEXT:    pop ix

--- a/llvm/utils/UpdateTestChecks/asm.py
+++ b/llvm/utils/UpdateTestChecks/asm.py
@@ -531,7 +531,7 @@ def get_run_handler(triple):
       'csky': (scrub_asm_csky, ASM_FUNCTION_CSKY_RE),
       'nvptx': (scrub_asm_nvptx, ASM_FUNCTION_NVPTX_RE),
       'loongarch32': (scrub_asm_loongarch, ASM_FUNCTION_LOONGARCH_RE),
-      'loongarch64': (scrub_asm_loongarch, ASM_FUNCTION_LOONGARCH_RE)
+      'loongarch64': (scrub_asm_loongarch, ASM_FUNCTION_LOONGARCH_RE),
       'z80': (scrub_asm_z80, ASM_FUNCTION_Z80_RE),
       'ez80': (scrub_asm_z80, ASM_FUNCTION_Z80_RE),
   }


### PR DESCRIPTION
This PR establishes a working baseline for v16.

# Fixes:

1. Tablegen Conflict Resolution
The z80 combiner included `identity_combines` and `const_combines` from the generic `Combine.td` which contain floating point rules (`fneg_fneg_fold`, `constant_fp_op`). These rules conflict when both match G_FNEG, causing TableGen to crash with ordering conflicts.

2. ValueAssigner Fix
These were both removed from the combiner's rule list. `z80_identity_combines` and `z80_const_combines` still include all integer optimizations from the upstream `identity_combines` and `const_combines` groups while excluding FP specific rules (`fneg_fneg_fold`, `constant_fp_op`, `combine_minmax_nan`)

3. CallLowering ValueAssigner
`lowerFormalArguments` was using `OutgoingValueAssigner` for arguments which are by definition incoming to the function. This caused incorrect calling convention handling.

3. MachineFunctionInfo v16 API
LVM v16 requires `TargetMachine` classes to override `createMachineFunctionInfo()` to allocate target specific `MachineFunctionInfo`. Without this, `MF.getInfo<Z80MachineFunctionInfo>()` returned null, crashing `FormalArgHandler::finalize()`

4. MIPatternMatch Double Optional and BitWidth
`matchConstant` specialization incorrectly dereferenced a potentially empty inner optional, causing ub when no constant was found. Checking only `Val.has_value()` verifies the outer optional but `Val.value()` (the inner optional) may still be nullopt.

Furthermore, the `matchConstant` specializations for integer types had guards like:

```cpp
if (Val && Val->getBitWidth() <= 64)
    return Val->getSExtValue();
```

When `getBitWidth() == 0`, this condition is true but `getSExtValue()` asserts with "Bit width can't be 0." a >0 guard was added to all affected specializations.


# Notes

Beyond these fixes, our port modified the upstream `MIPatternMatch.h` to add custom `matchConstant` specializations. This is problematic since future updates will conflict with these changes. I am also unsure how/if these propagate correctly 