### PR TITLE
Refactor MIPatternMatch usage to v16

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/CombinerHelper.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/CombinerHelper.h
@@ -78,7 +78,7 @@ struct PtrAddChain {
 
 struct FunnelShift {
   Register ShiftLeftReg, ShiftRightReg;
-  uint64_t ShiftLeftAmt;
+  int64_t ShiftLeftAmt;
 };
 
 struct RegisterImmPair {

--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -62,87 +62,20 @@ inline OneNonDBGUse_match<SubPat> m_OneNonDBGUse(const SubPat &SP) {
   return SP;
 }
 
-struct IgnoreMatch {
-  IgnoreMatch() = default;
-  IgnoreMatch(const IgnoreMatch &) = default;
-  const IgnoreMatch &operator=(const IgnoreMatch &) const { return *this; }
-};
-
 template <typename ConstT>
-std::optional<ConstT> matchConstant(Register Reg, const MachineRegisterInfo &MRI);
+inline std::optional<ConstT> matchConstant(Register,
+                                           const MachineRegisterInfo &);
 
 template <>
-inline std::optional<std::optional<ValueAndVReg>>
-matchConstant<std::optional<ValueAndVReg>>(Register Reg,
-                                      const MachineRegisterInfo &MRI) {
-  return getIConstantVRegValWithLookThrough(Reg, MRI);
+inline std::optional<APInt> matchConstant(Register Reg,
+                                          const MachineRegisterInfo &MRI) {
+  return getIConstantVRegVal(Reg, MRI);
 }
 
 template <>
-inline std::optional<APInt> matchConstant<APInt>(Register Reg,
+inline std::optional<int64_t> matchConstant(Register Reg,
                                             const MachineRegisterInfo &MRI) {
-  const auto& Val = matchConstant<std::optional<ValueAndVReg>>(Reg, MRI);
-  if (Val.has_value() && Val.value().has_value())
-    return { Val.value()->Value };
-  return { std::nullopt };
-}
-
-template <>
-inline std::optional<const IgnoreMatch>
-matchConstant<const IgnoreMatch>(Register Reg, const MachineRegisterInfo &MRI) {
-  matchConstant<APInt>(Reg, MRI);
-  return std::optional<const IgnoreMatch>{ IgnoreMatch{} };
-}
-
-template <>
-inline std::optional<int64_t> matchConstant<int64_t>(Register Reg,
-                                                     const MachineRegisterInfo &MRI) {
-  auto Val = matchConstant<APInt>(Reg, MRI);
-  if (Val && Val->getBitWidth() > 0 && Val->getBitWidth() <= 64)
-    return Val->getSExtValue();
-  return std::nullopt;
-}
-
-template <>
-inline std::optional<uint64_t> matchConstant<uint64_t>(Register Reg,
-                                                       const MachineRegisterInfo &MRI) {
-  auto Val = matchConstant<APInt>(Reg, MRI);
-  if (Val && Val->getBitWidth() > 0 && Val->getBitWidth() <= 64)
-    return Val->getSExtValue();
-  return std::nullopt;
-}
-
-template <>
-inline std::optional<unsigned char> matchConstant<unsigned char>(Register Reg,
-                                                                 const MachineRegisterInfo &MRI) {
-  auto Val = matchConstant<APInt>(Reg, MRI);
-  if (Val && Val->getBitWidth() > 0 && Val->getBitWidth() <= 64)
-    return Val->getSExtValue();
-  return std::nullopt;
-}
-
-template <>
-inline std::optional<unsigned int> matchConstant<unsigned int>(Register Reg,
-                                                               const MachineRegisterInfo &MRI) {
-  auto Val = matchConstant<APInt>(Reg, MRI);
-  if (Val && Val->getBitWidth() > 0 && Val->getBitWidth() <= 64)
-    return Val->getSExtValue();
-  return std::nullopt;
-}
-
-template <>
-inline std::optional<bool> matchConstant<bool>(Register Reg,
-                                               const MachineRegisterInfo &MRI) {
-  auto Val = matchConstant<APInt>(Reg, MRI);
-  if (Val && Val->getBitWidth() > 0 && Val->getBitWidth() <= 64)
-    return Val->getSExtValue();
-  return std::nullopt;
-}
-
-template <>
-inline std::optional<ValueAndVReg> matchConstant<ValueAndVReg>(Register Reg,
-    const MachineRegisterInfo &MRI) {
-  return getIConstantVRegValWithLookThrough(Reg, MRI);
+  return getIConstantVRegSExtVal(Reg, MRI);
 }
 
 template <typename ConstT> struct ConstantMatch {
@@ -157,9 +90,11 @@ template <typename ConstT> struct ConstantMatch {
   }
 };
 
-inline ConstantMatch<const IgnoreMatch> m_ICst() {
-  static constexpr IgnoreMatch ignore;
-  return {ignore};
+inline ConstantMatch<APInt> m_ICst(APInt &Cst) {
+  return ConstantMatch<APInt>(Cst);
+}
+inline ConstantMatch<int64_t> m_ICst(int64_t &Cst) {
+  return ConstantMatch<int64_t>(Cst);
 }
 
 template <typename ConstT>
@@ -212,10 +147,6 @@ struct GCstAndRegMatch {
     return ValReg ? true : false;
   }
 };
-
-template <typename ConstT> inline ConstantMatch<ConstT> m_ICst(ConstT &Cst) {
-  return {Cst};
-}
 
 inline GCstAndRegMatch m_GCst(std::optional<ValueAndVReg> &ValReg) {
   return GCstAndRegMatch(ValReg);
@@ -394,25 +325,34 @@ template <typename BindTy> struct bind_helper {
 template <> struct bind_helper<MachineInstr *> {
   static bool bind(const MachineRegisterInfo &MRI, MachineInstr *&MI,
                    Register Reg) {
-    return MI = MRI.getVRegDef(Reg);
+    MI = MRI.getVRegDef(Reg);
+    if (MI)
+      return true;
+    return false;
   }
   static bool bind(const MachineRegisterInfo &MRI, MachineInstr *&MI,
                    MachineInstr *Inst) {
-    return MI = Inst;
+    MI = Inst;
+    return MI;
   }
 };
 
 template <> struct bind_helper<LLT> {
-  static bool bind(const MachineRegisterInfo &MRI, LLT &Ty, Register Reg) {
+  static bool bind(const MachineRegisterInfo &MRI, LLT Ty, Register Reg) {
     Ty = MRI.getType(Reg);
-    return Ty.isValid();
+    if (Ty.isValid())
+      return true;
+    return false;
   }
 };
 
 template <> struct bind_helper<const ConstantFP *> {
   static bool bind(const MachineRegisterInfo &MRI, const ConstantFP *&F,
                    Register Reg) {
-    return F = getConstantFPVRegVal(Reg, MRI);
+    F = getConstantFPVRegVal(Reg, MRI);
+    if (F)
+      return true;
+    return false;
   }
 };
 
@@ -428,7 +368,7 @@ template <typename Class> struct bind_ty {
 
 inline bind_ty<Register> m_Reg(Register &R) { return R; }
 inline bind_ty<MachineInstr *> m_MInstr(MachineInstr *&MI) { return MI; }
-inline bind_ty<LLT> m_Type(LLT &Ty) { return Ty; }
+inline bind_ty<LLT> m_Type(LLT Ty) { return Ty; }
 inline bind_ty<CmpInst::Predicate> m_Pred(CmpInst::Predicate &P) { return P; }
 inline operand_type_match m_Pred() { return operand_type_match(); }
 
@@ -445,25 +385,6 @@ inline ImplicitDefMatch m_GImplicitDef() { return ImplicitDefMatch(); }
 
 // Helper for matching G_FCONSTANT
 inline bind_ty<const ConstantFP *> m_GFCst(const ConstantFP *&C) { return C; }
-
-template <typename Class> struct specific_ty {
-  Class RequestedVal;
-
-  specific_ty(Class RequestedVal) : RequestedVal(RequestedVal) {}
-
-  bool match(const MachineRegisterInfo &MRI, Register Reg) {
-    Class MatchedVal;
-    return mi_match(Reg, MRI, bind_ty<Class>(MatchedVal)) &&
-           MatchedVal == RequestedVal;
-  }
-};
-
-inline specific_ty<MachineInstr *> m_SpecificMInstr(MachineInstr *MI) {
-  return MI;
-}
-inline specific_ty<CmpInst::Predicate> m_SpecificPred(CmpInst::Predicate P) {
-  return P;
-}
 
 // General helper for all the binary generic MI such as G_ADD/G_SUB etc
 template <typename LHS_P, typename RHS_P, unsigned Opcode,
@@ -733,13 +654,18 @@ struct CompareOp_match {
     if (!mi_match(Op, MRI, m_MInstr(TmpMI)) || TmpMI->getOpcode() != Opcode)
       return false;
 
-    auto TmpPred = CmpInst::Predicate(TmpMI->getOperand(1).getPredicate());
-    return (P.match(MRI, TmpPred) &&
-            L.match(MRI, TmpMI->getOperand(2).getReg()) &&
-            R.match(MRI, TmpMI->getOperand(3).getReg())) ||
-           (P.match(MRI, CmpInst::getSwappedPredicate(TmpPred)) &&
-            R.match(MRI, TmpMI->getOperand(2).getReg()) &&
-            L.match(MRI, TmpMI->getOperand(3).getReg()));
+    auto TmpPred =
+        static_cast<CmpInst::Predicate>(TmpMI->getOperand(1).getPredicate());
+    if (!P.match(MRI, TmpPred))
+      return false;
+    Register LHS = TmpMI->getOperand(2).getReg();
+    Register RHS = TmpMI->getOperand(3).getReg();
+    if (L.match(MRI, LHS) && R.match(MRI, RHS))
+      return true;
+    if (Commutable && L.match(MRI, RHS) && R.match(MRI, LHS) &&
+        P.match(MRI, CmpInst::getSwappedPredicate(TmpPred)))
+      return true;
+    return false;
   }
 };
 

--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -907,6 +907,10 @@ void CombinerHelper::applySextInRegOfLoad(
   MI.eraseFromParent();
 }
 
+// Z80-FORK-START: CUSTOM-HELPERS
+// helper functions not found in upstream v17
+// this block should be kept when rebasing to 17+, check for conflicts
+
 bool CombinerHelper::dominates(MachineBasicBlock &DefMBB,
                                MachineBasicBlock &UseMBB) {
   if (MDT)
@@ -937,6 +941,8 @@ bool CombinerHelper::canMove(MachineInstr &MI, MachineBasicBlock &MBB,
   }
   return true;
 }
+
+// Z80-FORK-END: CUSTOM-HELPERS
 
 bool CombinerHelper::findPostIndexCandidate(MachineInstr &MI, Register &Addr,
                                             Register &Base, Register &Offset) {
@@ -4661,9 +4667,9 @@ bool CombinerHelper::matchReassocConstantInnerLHS(GPtrAdd &MI,
   // G_PTR_ADD (G_PTR_ADD X, C), Y) -> (G_PTR_ADD (G_PTR_ADD(X, Y), C)
   // if and only if (G_PTR_ADD X, C) has one use.
   Register LHSBase;
-  ValueAndVReg LHSCstOff;
+  std::optional<ValueAndVReg> LHSCstOff;
   if (!mi_match(MI.getBaseReg(), MRI,
-                m_OneNonDBGUse(m_GPtrAdd(m_Reg(LHSBase), m_ICst(LHSCstOff)))))
+                m_OneNonDBGUse(m_GPtrAdd(m_Reg(LHSBase), m_GCst(LHSCstOff)))))
     return false;
 
   auto *LHSPtrAdd = cast<GPtrAdd>(LHS);
@@ -4674,7 +4680,7 @@ bool CombinerHelper::matchReassocConstantInnerLHS(GPtrAdd &MI,
     LHSPtrAdd->moveBefore(&MI);
     Register RHSReg = MI.getOffsetReg();
     // set VReg will cause type mismatch if it comes from extend/trunc
-    auto NewCst = B.buildConstant(MRI.getType(RHSReg), LHSCstOff.Value);
+    auto NewCst = B.buildConstant(MRI.getType(RHSReg), LHSCstOff->Value);
     Observer.changingInstr(MI);
     MI.getOperand(2).setReg(NewCst.getReg(0));
     Observer.changedInstr(MI);
@@ -6236,6 +6242,11 @@ bool CombinerHelper::matchRedundantBinOpInEquality(MachineInstr &MI,
   return CmpInst::isEquality(Pred) && Y.isValid();
 }
 
+// Z80-FORK-START: CUSTOM-COMBINERS
+// These are Z80-specific generic improvements not found in upstream v17.
+// WHEN REBASING TO v17+: Keep this block, but check for conflicts.
+// Consider upstreaming these improvements to LLVM.
+
 bool CombinerHelper::matchPtrAddGlobalImmed(
     MachineInstr &MI, std::pair<const GlobalValue *, int64_t> &MatchInfo) {
   // We're trying to match the following pattern:
@@ -6354,12 +6365,15 @@ bool CombinerHelper::matchReassocFoldConstants(MachineInstr &MI,
           Opc == TargetOpcode::G_XOR) &&
          "Expected associative opcode");
 
+  // Z80-FORK-START: matchReassocFoldConstants pattern matching
+  int64_t _Unused1, _Unused2; // dummy vars for upstream api
   return mi_match(
       MI, MRI,
       m_CommutativeBinOp(Opc,
                          m_OneNonDBGUse(m_CommutativeBinOp(
-                             Opc, m_Reg(), m_all_of(m_ICst(), m_Reg(Regs[0])))),
-                         m_all_of(m_ICst(), m_Reg(Regs[1]))));
+                             Opc, m_Reg(), m_all_of(m_ICst(_Unused1), m_Reg(Regs[0])))),
+                         m_all_of(m_ICst(_Unused2), m_Reg(Regs[1]))));
+  // Z80-FORK-END
 }
 
 void CombinerHelper::applyReassocFoldConstants(MachineInstr &MI,
@@ -6484,13 +6498,13 @@ bool CombinerHelper::applyCombineOrToAdd(MachineInstr &MI) {
 bool CombinerHelper::matchCombineFunnelShift(MachineInstr &MI,
                                              FunnelShift &MatchInfo) {
   Register DstReg = MI.getOperand(0).getReg();
-  uint64_t ShiftRightAmt;
+  int64_t ShiftRightAmt;
   return mi_match(DstReg, MRI,
                   m_GAdd(m_GShl(m_Reg(MatchInfo.ShiftLeftReg),
                                 m_ICst(MatchInfo.ShiftLeftAmt)),
                          m_GLShr(m_Reg(MatchInfo.ShiftRightReg),
                                  m_ICst(ShiftRightAmt)))) &&
-         MatchInfo.ShiftLeftAmt + ShiftRightAmt ==
+         static_cast<uint64_t>(MatchInfo.ShiftLeftAmt) + static_cast<uint64_t>(ShiftRightAmt) ==
              MRI.getType(DstReg).getSizeInBits();
 }
 
@@ -6903,7 +6917,7 @@ void CombinerHelper::applyNarrowICmp(MachineInstr &MI,
 bool CombinerHelper::matchSimplifyICmpBool(MachineInstr &MI,
                                            RegisterImmPair &MatchInfo) {
   CmpInst::Predicate Pred;
-  bool CmpVal;
+  int64_t CmpVal; // Z80-FORK: changed from bool to int64_t for upstream api
   if (!mi_match(MI.getOperand(0).getReg(), MRI,
                 m_GICmp(m_Pred(Pred), m_Reg(MatchInfo.Reg), m_ICst(CmpVal))) ||
       MRI.getType(MatchInfo.Reg) != LLT::scalar(1))
@@ -6912,9 +6926,10 @@ bool CombinerHelper::matchSimplifyICmpBool(MachineInstr &MI,
   LLVMContext &C = MI.getParent()->getParent()->getFunction().getContext();
   MatchInfo.Imm = 0;
   ConstantInt *BoolCI[2] = {ConstantInt::getFalse(C), ConstantInt::getTrue(C)};
+  bool CmpBool = (CmpVal != 0); // Z80-FORK: convert back to bool for indexing
   for (ConstantInt *InCI : BoolCI)
     if (Constant *ResC =
-            ConstantExpr::getCompare(Pred, InCI, BoolCI[CmpVal], true))
+            ConstantExpr::getCompare(Pred, InCI, BoolCI[CmpBool], true))
       MatchInfo.Imm = MatchInfo.Imm << 1 | (ResC == BoolCI[true]);
     else
       return false;
@@ -7138,6 +7153,8 @@ void CombinerHelper::applySinkConstant(MachineInstr &MI,
   MI.removeFromParent();
   DomUseMI.getParent()->insert(DomUseMI, &MI);
 }
+
+// Z80-FORK-END: CUSTOM-COMBINERS
 
 bool CombinerHelper::tryCombine(MachineInstr &MI) {
   if (tryCombineCopy(MI))

--- a/llvm/lib/Target/Z80/GISel/Z80InstructionSelector.cpp
+++ b/llvm/lib/Target/Z80/GISel/Z80InstructionSelector.cpp
@@ -1447,13 +1447,13 @@ Z80InstructionSelector::foldCompare(MachineInstr &I, MachineIRBuilder &MIB,
     if (!ConstRHS->Value && (CC == Z80::COND_Z || CC == Z80::COND_NZ)) {
       if (OpSize == 8) {
         Register SrcReg;
-        uint8_t Mask;
+        int64_t Mask;
         if (mi_match(LHSReg, MRI,
                      m_OneUse(m_GAnd(m_Reg(SrcReg), m_ICst(Mask)))) &&
-            isPowerOf2_32(Mask)) {
+            Mask > 0 && isPowerOf2_64(static_cast<uint64_t>(Mask))) {
           Opc = Z80::BIT8gb;
           Reg = {};
-          Ops = {SrcReg, uint64_t(findFirstSet(Mask))};
+          Ops = {SrcReg, uint64_t(findFirstSet(static_cast<uint64_t>(Mask)))};
         } else {
           Opc = Z80::OR8ar;
           Ops = {Reg};

--- a/llvm/lib/Target/Z80/GISel/Z80PreLegalizerCombiner.cpp
+++ b/llvm/lib/Target/Z80/GISel/Z80PreLegalizerCombiner.cpp
@@ -72,7 +72,7 @@ static bool matchCombineTruncShift(MachineInstr &MI, MachineRegisterInfo &MRI,
   LLT DstTy = MRI.getType(DstReg);
   if (DstTy != LLT::scalar(8))
     return false;
-  unsigned ShiftAmt;
+  int64_t ShiftAmt;
   if (!mi_match(DstReg, MRI,
                 m_GTrunc(m_GLShr(m_Reg(SrcReg), m_ICst(ShiftAmt)))) ||
       ShiftAmt != 8)
@@ -93,7 +93,7 @@ static void applyCombineTruncShift(MachineInstr &MI, MachineIRBuilder &Builder,
 
 static bool matchFlipSetCCCond(MachineInstr &MI, MachineRegisterInfo &MRI,
                                MachineInstr *&SetCCMI) {
-  bool Imm;
+  int64_t Imm;
   return mi_match(MI.getOperand(0).getReg(), MRI,
                   m_GXor(m_OneUse(m_MInstr(SetCCMI)), m_ICst(Imm))) &&
          SetCCMI->getOpcode() == Z80::SetCC && Imm;

--- a/llvm/unittests/Target/Z80/InstSizes.cpp
+++ b/llvm/unittests/Target/Z80/InstSizes.cpp
@@ -1,6 +1,5 @@
 #include "Z80Subtarget.h"
 #include "Z80TargetMachine.h"
-#include "llvm/ADT/STLArrayExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/CodeGen/MIRParser/MIRParser.h"
@@ -1480,7 +1479,7 @@ void checkInstructionSizes(StringRef T) {
   ASSERT_TRUE(TheTarget);
 
   std::unique_ptr<Z80TargetMachine> TM(static_cast<Z80TargetMachine *>(
-      TheTarget->createTargetMachine(TT, "generic", "", {}, None)));
+      TheTarget->createTargetMachine(TT, "generic", "", {}, std::nullopt)));
   ASSERT_TRUE(TM);
 
   Z80Subtarget STI(TM->getTargetTriple(), TM->getTargetCPU(),
@@ -1533,7 +1532,7 @@ void checkInstructionSizes(StringRef T) {
   ASSERT_TRUE(F);
   auto &MF = MMI.getOrCreateMachineFunction(*F);
 
-  ASSERT_EQ(MF.getInstructionCount(), array_lengthof(TestInstrs));
+  ASSERT_EQ(MF.getInstructionCount(), std::size(TestInstrs));
   auto TI = std::begin(TestInstrs);
   for (const auto &MBB : MF)
     for (const auto &MI : MBB) {


### PR DESCRIPTION
- Revert MIPatternMatch.h to upstream v16.0.6
- Fix CombinerHelper.cpp to use `m_ICst(int64_t&)` and `m_GCst()`
- Fix z80 backend files to use `int64_t` for pattern matching
- Fix InstSizes.cpp