### PR TITLE
Fix overflowing add codegen, plus other fixes based on test output

### DIFF
--- a/llvm/lib/Target/Z80/GISel/Z80InstructionSelector.cpp
+++ b/llvm/lib/Target/Z80/GISel/Z80InstructionSelector.cpp
@@ -89,12 +89,14 @@ private:
                           MachineRegisterInfo &MRI) const;
   Z80::CondCode foldCond(Register CondReg, MachineIRBuilder &MIB,
                          MachineRegisterInfo &MRI,
-                         Z80::CondCode PreferredCC = Z80::COND_INVALID) const;
+                         Z80::CondCode PreferredCC = Z80::COND_INVALID,
+                         bool EmitFallback = true) const;
   bool selectShift(MachineInstr &I, MachineRegisterInfo &MRI) const;
   bool selectAddSub(MachineInstr &I, MachineRegisterInfo &MRI) const;
   bool selectFunnelShift(MachineInstr &I, MachineRegisterInfo &MRI) const;
   bool selectSetCond(unsigned ExtOpc, Register DstReg, Register CondReg,
-                     MachineInstr &I, MachineRegisterInfo &MRI) const;
+                     MachineInstr &I, MachineRegisterInfo &MRI,
+                     bool EmitFallback = true) const;
   bool selectSetCond(unsigned ExtOpc, MachineInstr &I,
                      MachineRegisterInfo &MRI) const {
     Register CondReg = I.getOperand(I.getNumExplicitDefs() - 1).getReg();
@@ -521,7 +523,7 @@ bool Z80InstructionSelector::selectSExt(MachineInstr &I,
   // handle s1 -> sN sign extension (boolean to integer), result is 0 or -1
   if (SrcTy == LLT::scalar(1)) {
     if (DstTy.getSizeInBits() <= 24 && MRI.hasOneUse(SrcReg) &&
-        selectSetCond(I.getOpcode(), DstReg, SrcReg, I, MRI))
+        selectSetCond(I.getOpcode(), DstReg, SrcReg, I, MRI, false))
       return true;
 
     unsigned FillOpc;
@@ -1113,7 +1115,7 @@ bool Z80InstructionSelector::selectZExt(MachineInstr &I,
   // Handle s1 -> sN zero extension (boolean to integer)
   if (SrcTy == LLT::scalar(1)) {
     if (MRI.hasOneUse(SrcReg) &&
-        selectSetCond(I.getOpcode(), DstReg, SrcReg, I, MRI))
+        selectSetCond(I.getOpcode(), DstReg, SrcReg, I, MRI, false))
       return true;
 
     MachineIRBuilder MIB(I);
@@ -1258,7 +1260,7 @@ bool Z80InstructionSelector::selectAnyExt(MachineInstr &I,
   const Register DstReg = I.getOperand(0).getReg();
 
   if (MRI.getType(SrcReg) == LLT::scalar(1) && MRI.hasOneUse(SrcReg) &&
-      selectSetCond(I.getOpcode(), DstReg, SrcReg, I, MRI))
+      selectSetCond(I.getOpcode(), DstReg, SrcReg, I, MRI, false))
     return true;
 
   const TargetRegisterClass *DstRC = getRegClass(DstReg, MRI);
@@ -2347,10 +2349,10 @@ static bool canMoveDefForwards(MachineOperand &Def, MachineInstr &TargetMI) {
   if (!Reg.isVirtual() || !MBB || MBB != TargetMI.getParent())
     return false;
   for (MachineBasicBlock::iterator I(MI), E(MBB->end()); ++I != E;) {
-    if (I->readsVirtualRegister(Reg))
-        return false;
     if (I == TargetMI)
       return true;
+    if (I->readsVirtualRegister(Reg))
+        return false;
   }
   return false;
 }
@@ -2380,6 +2382,11 @@ Z80::CondCode Z80InstructionSelector::foldExtendedAddSub(
   std::optional<ValueAndVReg> RHSConst = std::nullopt;
   LLT OpTy = MRI.getType(DstReg);
 
+  bool IsThisInstr = (I == MIB.getInsertPt());
+  bool MoveDef = !IsThisInstr && canMoveDefForwards(DstMO, *MIB.getInsertPt());
+  if (!IsThisInstr && !MoveDef)
+    return Z80::COND_INVALID;
+
   unsigned AddSubOpc;
   bool NeedCarry;
   Register AddSubReg;
@@ -2396,14 +2403,14 @@ Z80::CondCode Z80InstructionSelector::foldExtendedAddSub(
     AddSubRC = &Z80::R8RegClass;
     break;
   case 16:
-    AddSubOpc = IsAdd ? IsExtend ? Z80::ADC16ao : Z80::ADD16ao : Z80::SBC16ao;
-    if ((NeedCarry = !IsAdd || IsExtend))
+    AddSubOpc = IsAdd ? (IsExtend || IsSigned) ? Z80::ADC16ao : Z80::ADD16ao : Z80::SBC16ao;
+    if ((NeedCarry = (AddSubOpc != Z80::ADD16ao)))
       AddSubReg = Z80::HL;
     AddSubRC = &Z80::R16RegClass;
     break;
   case 24:
-    AddSubOpc = IsAdd ? IsExtend ? Z80::ADC24ao : Z80::ADD24ao : Z80::SBC24ao;
-    if ((NeedCarry = !IsAdd || IsExtend))
+    AddSubOpc = IsAdd ? (IsExtend || IsSigned) ? Z80::ADC24ao : Z80::ADD24ao : Z80::SBC24ao;
+    if ((NeedCarry = (AddSubOpc != Z80::ADD24ao)))
       AddSubReg = Z80::UHL;
     AddSubRC = &Z80::R24RegClass;
     break;
@@ -2413,7 +2420,7 @@ Z80::CondCode Z80InstructionSelector::foldExtendedAddSub(
 
   if (IsExtend) {
     Register CarryInReg = I.getOperand(4).getReg();
-    Z80::CondCode CC = foldCond(CarryInReg, MIB, MRI);
+    Z80::CondCode CC = foldCond(CarryInReg, MIB, MRI, Z80::COND_C);
     if (CC == Z80::COND_INVALID)
       return CC;
     if (CC != Z80::COND_C) {
@@ -2428,8 +2435,7 @@ Z80::CondCode Z80InstructionSelector::foldExtendedAddSub(
     }
   } else if (NeedCarry)
     MIB.buildInstr(Z80::RCF);
-  bool MoveDef =
-      I == MIB.getInsertPt() || canMoveDefForwards(DstMO, *MIB.getInsertPt());
+
   SmallVector<DstOp, 1> DstOps;
   SmallVector<SrcOp, 2> SrcOps;
   if (AddSubReg.isValid()) {
@@ -2437,8 +2443,7 @@ Z80::CondCode Z80InstructionSelector::foldExtendedAddSub(
     if (!RBI.constrainGenericRegister(LHSReg, *AddSubRC, MRI))
       return Z80::COND_INVALID;
   } else {
-    DstOps.push_back(MoveDef ? DstReg
-                             : createGenericVirtualRegister(MRI, OpTy));
+    DstOps.push_back(DstReg);
     SrcOps.push_back(LHSReg);
   }
   if (RHSConst)
@@ -2448,13 +2453,15 @@ Z80::CondCode Z80InstructionSelector::foldExtendedAddSub(
   MachineInstrBuilder AddSubI = MIB.buildInstr(AddSubOpc, DstOps, SrcOps);
   if (!constrainSelectedInstRegOperands(*AddSubI, TII, TRI, RBI))
     return Z80::COND_INVALID;
+  if (AddSubReg.isValid()) {
+    MIB.buildCopy(DstReg, AddSubReg);
+    if (!RBI.constrainGenericRegister(DstReg, *AddSubRC, MRI))
+      return Z80::COND_INVALID;
+  }
   if (MoveDef) {
+    assert(MRI.hasOneUse(I.getOperand(1).getReg()) &&
+           "should not be folding condition with multiple uses");
     DstMO.setReg(createGenericVirtualRegister(MRI, OpTy));
-    if (AddSubReg.isValid()) {
-      MIB.buildCopy(DstReg, AddSubReg);
-      if (!RBI.constrainGenericRegister(DstReg, *AddSubRC, MRI))
-        return Z80::COND_INVALID;
-    }
   }
   return IsSigned ? Z80::COND_PE : Z80::COND_C;
 }
@@ -2484,7 +2491,8 @@ Z80InstructionSelector::foldSetCC(MachineInstr &I, MachineIRBuilder &MIB,
 Z80::CondCode
 Z80InstructionSelector::foldCond(Register CondReg, MachineIRBuilder &MIB,
                                  MachineRegisterInfo &MRI,
-                                 Z80::CondCode PreferredCC) const {
+                                 Z80::CondCode PreferredCC,
+                                 bool EmitFallback) const {
   const LLT s1 = LLT::scalar(1), s8 = LLT::scalar(8);
   assert(MRI.getType(CondReg) == s1 && "Expected s1 condition");
 
@@ -2552,7 +2560,7 @@ Z80InstructionSelector::foldCond(Register CondReg, MachineIRBuilder &MIB,
     }
   }
 
-  if (CC == Z80::COND_INVALID) {
+  if (CC == Z80::COND_INVALID && EmitFallback) {
     // Fallback to rotate/bit test
     const TargetRegisterClass *CondRC;
     switch (PreferredCC) {
@@ -3026,7 +3034,8 @@ bool Z80InstructionSelector::selectFunnelShift(MachineInstr &I,
 
 bool Z80InstructionSelector::selectSetCond(unsigned ExtOpc, Register DstReg,
                                            Register CondReg, MachineInstr &I,
-                                           MachineRegisterInfo &MRI) const {
+                                           MachineRegisterInfo &MRI,
+                                           bool EmitFallback) const {
   LLT DstTy = MRI.getType(DstReg);
 
   unsigned SetOpc, SelectOpc, IncOpc, FillOpc;
@@ -3067,7 +3076,7 @@ bool Z80InstructionSelector::selectSetCond(unsigned ExtOpc, Register DstReg,
   MachineIRBuilder MIB(I);
   Z80::CondCode DirectCC =
       ExtOpc == TargetOpcode::G_ZEXT ? Z80::COND_NC : Z80::COND_C;
-  Z80::CondCode CC = foldCond(CondReg, MIB, MRI, DirectCC);
+  Z80::CondCode CC = foldCond(CondReg, MIB, MRI, DirectCC, EmitFallback);
   if (CC == Z80::COND_INVALID)
     return false;
 

--- a/llvm/lib/Target/Z80/GISel/Z80InstructionSelector.cpp
+++ b/llvm/lib/Target/Z80/GISel/Z80InstructionSelector.cpp
@@ -1813,28 +1813,56 @@ bool Z80InstructionSelector::selectExtract(MachineInstr &I,
     I.setDesc(TII.get(TargetOpcode::EXTRACT_SUBREG));
     I.getOperand(2).setImm(SubIdx);
   } else if (Offset % 8 == 0) {
+    Register WideDstReg = DstReg;
+    const TargetRegisterClass *WideDstRC = DstRC;
+    Register WideSrcReg = SrcReg;
+    const TargetRegisterClass *WideSrcRC = SrcRC;
     unsigned Opc;
     MachineIRBuilder MIB(I);
     int FI = MF.getFrameInfo().CreateStackObject(
         TRI.getSpillSize(*SrcRC), TRI.getSpillAlign(*SrcRC), false);
-    if (SrcRC == &Z80::R8RegClass)
+    if (STI.is24Bit() && SrcRC == &Z80::R16RegClass) {
+      WideSrcRC = &Z80::R24RegClass;
+      if (SrcReg.isPhysical())
+        WideSrcReg = TRI.getMatchingSuperReg(SrcReg, Z80::sub_short,
+                                             WideSrcRC);
+      else
+        WideSrcReg = createGenericVirtualRegister(MRI, LLT::scalar(24));
+      if (!select(*MIB.buildAnyExt(WideSrcReg, SrcReg)) ||
+          !RBI.constrainGenericRegister(WideSrcReg, *WideSrcRC, MRI))
+        return false;
+    }
+    if (WideSrcRC == &Z80::R8RegClass)
       Opc = Z80::LD8or;
-    else if (SrcRC == &Z80::R16RegClass)
-      Opc = Z80::LD16or;
-    else if (SrcRC == &Z80::R24RegClass)
+    else if (WideSrcRC == &Z80::R16RegClass)
+      Opc = STI.has16BitEZ80Ops() ? Z80::LD16or : Z80::LD88or;
+    else if (WideSrcRC == &Z80::R24RegClass)
       Opc = Z80::LD24or;
     else
       return false;
-    MIB.buildInstr(Opc).addFrameIndex(FI).addImm(0).addReg(SrcReg);
-    if (DstRC == &Z80::R8RegClass)
+    MIB.buildInstr(Opc).addFrameIndex(FI).addImm(0).addReg(WideSrcReg);
+    if (STI.is24Bit() && DstRC == &Z80::R16RegClass) {
+      WideDstRC = &Z80::R24RegClass;
+      if (DstReg.isPhysical())
+        WideDstReg = TRI.getMatchingSuperReg(DstReg, Z80::sub_short,
+                                             WideDstRC);
+      else
+        WideDstReg = createGenericVirtualRegister(MRI, LLT::scalar(24));
+    }
+    if (WideDstRC == &Z80::R8RegClass)
       Opc = Z80::LD8ro;
-    else if (DstRC == &Z80::R16RegClass)
-      Opc = Z80::LD16ro;
-    else if (DstRC == &Z80::R24RegClass)
+    else if (WideDstRC == &Z80::R16RegClass)
+      Opc = STI.has16BitEZ80Ops() ? Z80::LD16ro : Z80::LD88ro;
+    else if (WideDstRC == &Z80::R24RegClass)
       Opc = Z80::LD24ro;
     else
       return false;
-    MIB.buildInstr(Opc, {DstReg}, {}).addFrameIndex(FI).addImm(Offset / 8);
+    MIB.buildInstr(Opc, {WideDstReg}, {}).addFrameIndex(FI).addImm(Offset / 8);
+    if (WideDstReg != DstReg) {
+      if (!select(*MIB.buildTrunc(DstReg, WideDstReg)) ||
+          !RBI.constrainGenericRegister(WideDstReg, *WideDstRC, MRI))
+        return false;
+    }
     I.eraseFromParent();
   } else
     return false;
@@ -2016,37 +2044,65 @@ bool Z80InstructionSelector::selectInsert(MachineInstr &I,
     I.tieOperands(0, 1);
     I.getOperand(3).setImm(SubIdx);
   } else if (Offset % 8 == 0) {
+    Register WideDstReg = DstReg;
+    const TargetRegisterClass *WideDstRC = DstRC;
+    Register WideSrcReg = SrcReg;
+    const TargetRegisterClass *WideSrcRC = SrcRC;
     unsigned Opc;
     MachineIRBuilder MIB(I);
     int FI = MF.getFrameInfo().CreateStackObject(
         TRI.getSpillSize(*SrcRC), TRI.getSpillAlign(*SrcRC), false);
-    if (SrcRC == &Z80::R8RegClass)
+    if (STI.is24Bit() && SrcRC == &Z80::R16RegClass) {
+      WideSrcRC = &Z80::R24RegClass;
+      if (SrcReg.isPhysical())
+        WideSrcReg = TRI.getMatchingSuperReg(SrcReg, Z80::sub_short,
+                                             WideSrcRC);
+      else
+        WideSrcReg = createGenericVirtualRegister(MRI, LLT::scalar(24));
+      if (!select(*MIB.buildAnyExt(WideSrcReg, SrcReg)) ||
+          !RBI.constrainGenericRegister(WideSrcReg, *WideSrcRC, MRI))
+        return false;
+    }
+    if (WideSrcRC == &Z80::R8RegClass)
       Opc = Z80::LD8or;
-    else if (SrcRC == &Z80::R16RegClass)
-      Opc = Z80::LD16or;
-    else if (SrcRC == &Z80::R24RegClass)
+    else if (WideSrcRC == &Z80::R16RegClass)
+      Opc = STI.has16BitEZ80Ops() ? Z80::LD16or : Z80::LD88or;
+    else if (WideSrcRC == &Z80::R24RegClass)
       Opc = Z80::LD24or;
     else
       return false;
-    MIB.buildInstr(Opc).addFrameIndex(FI).addImm(0).addReg(SrcReg);
+    MIB.buildInstr(Opc).addFrameIndex(FI).addImm(0).addReg(WideSrcReg);
     if (InsertRC == &Z80::R8RegClass)
       Opc = Z80::LD8or;
     else if (InsertRC == &Z80::R16RegClass)
-      Opc = Z80::LD16or;
+      Opc = STI.has16BitEZ80Ops() ? Z80::LD16or : Z80::LD88or;
     else if (InsertRC == &Z80::R24RegClass)
       Opc = Z80::LD24or;
     else
       return false;
     MIB.buildInstr(Opc).addFrameIndex(FI).addImm(Offset / 8).addReg(InsertReg);
-    if (DstRC == &Z80::R8RegClass)
+    if (STI.is24Bit() && DstRC == &Z80::R16RegClass) {
+      WideDstRC = &Z80::R24RegClass;
+      if (DstReg.isPhysical())
+        WideDstReg = TRI.getMatchingSuperReg(DstReg, Z80::sub_short,
+                                             WideDstRC);
+      else
+        WideDstReg = createGenericVirtualRegister(MRI, LLT::scalar(24));
+    }
+    if (WideDstRC == &Z80::R8RegClass)
       Opc = Z80::LD8ro;
-    else if (DstRC == &Z80::R16RegClass)
-      Opc = Z80::LD16ro;
-    else if (DstRC == &Z80::R24RegClass)
+    else if (WideDstRC == &Z80::R16RegClass)
+      Opc = STI.has16BitEZ80Ops() ? Z80::LD16ro : Z80::LD88ro;
+    else if (WideDstRC == &Z80::R24RegClass)
       Opc = Z80::LD24ro;
     else
       return false;
-    MIB.buildInstr(Opc, {DstReg}, {}).addFrameIndex(FI).addImm(0);
+    MIB.buildInstr(Opc, {WideDstReg}, {}).addFrameIndex(FI).addImm(0);
+    if (WideDstReg != DstReg) {
+      if (!select(*MIB.buildTrunc(DstReg, WideDstReg)) ||
+          !RBI.constrainGenericRegister(WideDstReg, *WideDstRC, MRI))
+        return false;
+    }
     I.eraseFromParent();
   } else
     return false;

--- a/llvm/lib/Target/Z80/GISel/Z80LegalizerInfo.cpp
+++ b/llvm/lib/Target/Z80/GISel/Z80LegalizerInfo.cpp
@@ -1747,36 +1747,96 @@ Z80LegalizerInfo::legalizeMergeValues(LegalizerHelper &Helper,
                                       MachineInstr &MI) const {
   // this handles G_MERGE_VALUES with s1 source operands
   // example: %dst:_(s8) = G_MERGE_VALUES %0:_(s1), %1:_(s1), ...
-  // theyre expanded  into zero extends, shifts, and ORs
-  //   %ext0 = G_ZEXT %0 -> s8
-  //   %ext1 = G_ZEXT %1 -> s8
-  //   %shl1 = G_SHL %ext1, 1
-  //   %or0 = G_OR %ext0, %shl1
+  // they're expanded into zero extends, shifts, and adds,
+  // in a way that minimizes the total number of bits shifted
+  //   %ext7 = G_ANYEXT %7 -> s8
+  //   %shl6 = G_SHL %ext7, 1
+  //   %ext6 = G_ZEXT %6 -> s8
+  //   %add6 = G_ADD %shl6, %ext6
+  //   %shl5 = G_SHL %add6, 1
   //   ... and so on
+  // any constant operands are skipped during this process and
+  // added at the end
   MachineIRBuilder &MIRBuilder = Helper.MIRBuilder;
   MachineRegisterInfo &MRI = *MIRBuilder.getMRI();
 
   Register DstReg = MI.getOperand(0).getReg();
   LLT DstTy = MRI.getType(DstReg);
 
-  // start with the first source, zero extended to dst type
-  Register Src0 = MI.getOperand(1).getReg();
-  Register Result = MIRBuilder.buildZExt(DstTy, Src0).getReg(0);
+  // iterate sources in reverse to propagate const/undef
+  bool AllUndef = true;
+  unsigned I, BitCount = MI.getNumOperands() - 1;
+  auto ConstantBits = APInt::getZero(BitCount);
+  for (I = BitCount; I > 0; I--) {
+    MachineOperand SrcOperand = MI.getOperand(I);
+    if (SrcOperand.isUndef())
+      continue;
+    if (auto ConstSrc =
+            getIConstantVRegValWithLookThrough(SrcOperand.getReg(), MRI)) {
+      AllUndef = false;
+      if (!ConstSrc->Value.isZero())
+        ConstantBits.setBit(I - 1);
+    } else {
+      break;
+    }
+  }
 
-  // for each subsequent source, zext it, shift it, and OR into result
-  for (unsigned I = 2, E = MI.getNumOperands(); I < E; ++I) {
+  MachineInstrBuilder Result;
+  if (I == 0) {
+    // if no non-constant register was found, set the result directly
+    if (AllUndef)
+      Result = MIRBuilder.buildUndef(DstTy);
+    else
+      Result = MIRBuilder.buildConstant(DstTy, ConstantBits);
+  } else {
+    // extend the highest non-constant register
     Register SrcReg = MI.getOperand(I).getReg();
-    unsigned ShiftAmt = I - 1;
+    if (AllUndef)
+      Result = MIRBuilder.buildAnyExt(DstTy, SrcReg);
+    else
+      Result = MIRBuilder.buildZExt(DstTy, SrcReg);
 
-    // zero extend the s1 to the destination type
-    auto ZExt = MIRBuilder.buildZExt(DstTy, SrcReg);
+    // for the remaining registers, shift the result left and add them in
+    // possible future improvement: fold to carry flag and rotate left
+    unsigned ShiftAmt = 0;
+    while (--I > 0) {
+      ShiftAmt++;
+      MachineOperand SrcOperand = MI.getOperand(I);
+      if (SrcOperand.isUndef())
+        continue;
+      Register SrcReg = SrcOperand.getReg();
+      if (auto ConstSrc = getIConstantVRegValWithLookThrough(SrcReg, MRI)) {
+        if (!ConstSrc->Value.isZero())
+          ConstantBits.setBit(I - 1);
+        continue;
+      }
 
-    // shift left by the bit position
-    auto ShiftCst = MIRBuilder.buildConstant(DstTy, ShiftAmt);
-    auto Shifted = MIRBuilder.buildShl(DstTy, ZExt, ShiftCst);
+      // shift left by the number of iterations since the last shift
+      auto ShiftCst = MIRBuilder.buildConstant(DstTy, ShiftAmt);
+      Result = MIRBuilder.buildShl(DstTy, Result, ShiftCst);
+      ShiftAmt = 0;
 
-    // OR into the accumulated result
-    Result = MIRBuilder.buildOr(DstTy, Result, Shifted).getReg(0);
+      // zero extend the s1 to the destination type
+      auto ZExt = MIRBuilder.buildZExt(DstTy, SrcReg);
+
+      // add into the accumulated result
+      Result = MIRBuilder.buildAdd(
+          DstTy, Result, ZExt, MachineInstr::NoUWrap | MachineInstr::NoSWrap);
+    }
+
+    // do any leftover shift
+    if (ShiftAmt) {
+      auto ShiftCst = MIRBuilder.buildConstant(DstTy, ShiftAmt);
+      Result = MIRBuilder.buildShl(DstTy, Result, ShiftCst);
+    }
+
+    // finally, combine with constant bits
+    if (!ConstantBits.isZero()) {
+      auto Constant = MIRBuilder.buildConstant(DstTy, ConstantBits);
+      Result =
+          MIRBuilder.buildAdd(DstTy, Result, Constant,
+                              MachineInstr::NoUWrap | MachineInstr::NoSWrap);
+    }
   }
 
   MIRBuilder.buildCopy(DstReg, Result);


### PR DESCRIPTION
16-bit and 24-bit overflowing add now correctly generates ADC instead of ADD to obtain the overflow flag output. Additionally, the code generation for overflowing and extended add/sub has been updated to avoid performing the calculation twice when both the value and flag outputs are used.

In some cases, condition folding would generate fallback code even when the caller had its own fallback implementation, causing redundant instruction output. This has also been fixed by adding a parameter to indicate no fallback should be emitted when condition folding fails.

While looking at test output, I also identified and fixed the following issues:
* Implementations of the G_EXTRACT and G_INSERT opcodes were emitting 16-bit memory operations in 24-bit mode, when it should have been using 24-bit operations or 8-bit pseudo operations. This has been fixed to use 24-bit operations on loads (which are from stack slots and safe to overrun by one byte), pseudo 8-bit operations on stores for inserted subregs, and 24-bit operations for stores of a full 16-bit register (increasing the stack slot size if needed). Though, in most cases, extract/insert for full 16-bit registers will use direct subregister operations rather than stack slots in the first place.
* Fixed excessive code generation for G_MERGE_VALUES with s1 source operands, which was behavior introduced in v17. In many cases, the majority of the s1 source operands were constant or undef, intended for zero-ext or any-ext. So, to fix this issue, G_MERGE_VALUES has been optimized to account for constant or undef inputs, as well as minimize the total number of bits shifted.